### PR TITLE
changes to enable building as a submodule

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,21 +2,28 @@
 # See LICENSE.txt in the root of the source distribution for license info.
 
 cmake_minimum_required(VERSION 3.20)
-# make sure that INTEL_COMPILER exists
-if(NOT DEFINED ${INTEL_COMPILER})
-    message(FATAL_ERROR "INTEL_COMPILER must be defined")
-endif()
-set(CMAKE_CXX_COMPILER ${INTEL_COMPILER})
 
 # set the default CMAKE_INSTALL_PREFIX to the current directory/install
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE PATH "..." FORCE)
 endif()
 
+# print where MKLShim layer will be installed
+message(STATUS "H4I-MKLShim will be installed to: ${CMAKE_INSTALL_PREFIX}")
+
 include (${CMAKE_CURRENT_SOURCE_DIR}/CMake/MKLShimVersion.cmake)
 project(MKLShim
     VERSION ${MKLShim_VERSION}
     LANGUAGES CXX)
+
+# check if INTEL_COMPILER_PATH was passed to CMake invocation, if not, look for icpx in PATH
+if(NOT DEFINED INTEL_COMPILER_PATH)
+    find_program(INTEL_COMPILER_PATH icpx REQUIRED)
+    message(STATUS "Found Intel C++ Compiler: ${INTEL_COMPILER_PATH}")
+endif()
+
+set(CMAKE_CXX_COMPILER ${INTEL_COMPILER_PATH})
+set(CMAKE_CXX_COMPILER_ID "IntelLLVM")
 
 # Define a target capturing common configuration settings.
 # Although we use 'add_library' for this, it is not a library - 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,18 @@
 # See LICENSE.txt in the root of the source distribution for license info.
 
 cmake_minimum_required(VERSION 3.20)
-include (${CMAKE_SOURCE_DIR}/CMake/MKLShimVersion.cmake)
+# make sure that INTEL_COMPILER exists
+if(NOT DEFINED ${INTEL_COMPILER})
+    message(FATAL_ERROR "INTEL_COMPILER must be defined")
+endif()
+set(CMAKE_CXX_COMPILER ${INTEL_COMPILER})
+
+# set the default CMAKE_INSTALL_PREFIX to the current directory/install
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/install" CACHE PATH "..." FORCE)
+endif()
+
+include (${CMAKE_CURRENT_SOURCE_DIR}/CMake/MKLShimVersion.cmake)
 project(MKLShim
     VERSION ${MKLShim_VERSION}
     LANGUAGES CXX)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,9 +10,10 @@ add_library(MKLShim SHARED
     onemklsolver.cpp)
 target_include_directories(MKLShim
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-        $<INSTALL_INTERFACE:include>
-    )
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:include>
+)
+
 # When defining the library's link interface, ideally we would
 # use MKL::MKL_DPCPP. But then our "clients" will see this 
 # specific target as a dependency.  If those clients are not
@@ -36,13 +37,13 @@ install(TARGETS MKLShim
         EXPORT MKLShim
 )
 install(FILES 
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/mklshim.h
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/Context.h
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/Stream.h
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/types.h
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/common.h
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/onemklblas.h
-            ${CMAKE_SOURCE_DIR}/include/h4i/mklshim/onemklsolver.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/mklshim.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/Context.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/Stream.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/types.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/common.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/onemklblas.h
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include/h4i/mklshim/onemklsolver.h
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/h4i/mklshim/
     )
 
@@ -53,7 +54,7 @@ install(EXPORT MKLShim
 
 include(CMakePackageConfigHelpers)
 
-configure_package_config_file(${CMAKE_SOURCE_DIR}/CMake/MKLShimConfig.cmake.in
+configure_package_config_file(${CMAKE_CURRENT_SOURCE_DIR}/../CMake/MKLShimConfig.cmake.in
     ${CMAKE_CURRENT_BINARY_DIR}/MKLShimConfig.cmake
     PATH_VARS CMAKE_INSTALL_INCLUDEDIR
     INSTALL_DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/MKLShim


### PR DESCRIPTION
Since hipBLAS is a very frequently used library,  it makes much more sense to be able to build it in a single step. 

This replaces the previous version which was a fork of Sabojit's branch.