### PR TITLE
Enabling hipsolverSetStream and hipblasSetStream

### DIFF
--- a/include/h4i/mklshim/Stream.h
+++ b/include/h4i/mklshim/Stream.h
@@ -9,7 +9,6 @@ namespace H4I::MKLShim
 {
 
 constexpr const int nHandles = 4;
-void SetStream(Context* context, const std::array<uintptr_t, nHandles>& handles);
-
+void SetStream(Context* ctxt, unsigned long const* backendHandles, int numOfHandles, const char* backendName);
 } // namespace
 

--- a/src/Stream.cpp
+++ b/src/Stream.cpp
@@ -1,6 +1,6 @@
 // Copyright 2021-2023 UT-Battelle
 // See LICENSE.txt in the root of the source distribution for license info.
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <level_zero/ze_api.h>
 #include <sycl/ext/oneapi/backend/level_zero.hpp>
 #include "oneapi/mkl.hpp"
@@ -11,16 +11,15 @@ namespace H4I::MKLShim
 {
 
 void
-SetStream(Context* ctxt, const std::array<uintptr_t, nHandles>& nativeHandles)
+SetStream(Context* ctxt, unsigned long const* backendHandles, int numOfHandles, const char* backendName)
 {
     if(ctxt != nullptr)
     {
-        if (context_tbl.find(nativeHandles[3]) != context_tbl.end()) {
-            ctxt = context_tbl[nativeHandles[3]];
+        if (context_tbl.find(backendHandles[3]) != context_tbl.end()) {
+            ctxt = context_tbl[backendHandles[3]];
         } else {
             // new context hence update corresponding sycl queue and other structures .....
-            std::string backendName = (currentBackend == level0) ? "level0" : "opencl";
-            Update(ctxt, nativeHandles.data(), nativeHandles.size(), backendName.c_str());
+            Update(ctxt, backendHandles, numOfHandles, backendName);
         }
     }
 }


### PR DESCRIPTION
# Overview
This PR is to address hipsolverSetStream and hipblasSetStream not currently working.

This is one part of a PR which also affects H4I-hipSOLVER and H4I-hipBLAS. It address [PR #17](https://github.com/CHIP-SPV/H4I-HipSOLVER/issues/17) for hipSolver. The same issue shows up for streams and hipBLAS. 

These needs the following PRs in H4I-hipSOLVER and H4I-hipBLAS to work as well: https://github.com/CHIP-SPV/H4I-HipBLAS/pull/26 and https://github.com/CHIP-SPV/H4I-HipSOLVER/pull/18

The issue is with the following types of code:
```
# make a stream
  hipStream_t s;
  hipStreamCreate(&s);

# make a hipSOLVER handle
  hipsolverHandle_t bhandle;
  hipsolverCreate(&bhandle);
# this fails without this PR since the stream is not added in properly to the MKLshim context 
  hipsolverSetStream(bhandle, s);
```
Similarly, this fails without this PR:
```
# make a hipBLAS handle
    hipblasHandle_t handle;
    hipblasCreate(&handle);
    hipblasSetStream(handle, s);
```

## Description:
In `hipsolverSetStream(handle, s)`, we want to take the MKLShim handle and change it to use handles backed on the Stream s. In the current code (https://github.com/CHIP-SPV/H4I-HipSOLVER/blob/9ba7bf6caa09ac196a83d9f1b5e63d24c3761a5f/src/util.cpp#L46C19-L46C37) for hipsolver there are a few issues. For example, in https://github.com/CHIP-SPV/H4I-HipSOLVER/blob/9ba7bf6caa09ac196a83d9f1b5e63d24c3761a5f/src/util.cpp#L52, it uses a fixed number of handles of 4, which doesn't match the number of handles in the stream (it is 6 but changes to 5 for MKLShim to be similar to hipsolverCreate). 

Instead, I propose we should update the MKLShim context in a similar manner to how the hipsolverCreate (https://github.com/CHIP-SPV/H4I-HipSOLVER/blob/9ba7bf6caa09ac196a83d9f1b5e63d24c3761a5f/src/util.cpp#L6) (or hipblasCreate) handles the MKLShim context creation. The only difference between hipsolverCreate and hipsolverSetStream is that at the end of hipsolverCreate we call H4I::MKLShim::Create and at the end of hipsolverSetStream we call H4I::MKLShim::SetStream which calls H4I::MKLShim::Update. The H4I::MKLShim::SetStream is changed to just take in the same arguments as needed for H4I::MKLShim::Update, and to get the backendName and handles from the Stream handle. 

If there is another way to handle this, we can switch to that.
