### PR TITLE
Updating Context.cpp to use ”#ifdef UR_API_H_INCLUDED” and int64_t instead of std::int64_t for GCC13 

### DIFF
--- a/include/h4i/mklshim/onemklsolver.h
+++ b/include/h4i/mklshim/onemklsolver.h
@@ -127,13 +127,13 @@ namespace H4I::MKLShim
   int64_t Dgetrs_ScPadSz(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, int64_t lda, int64_t ldb);
   int64_t Cgetrs_ScPadSz(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, int64_t lda, int64_t ldb);
   int64_t Zgetrs_ScPadSz(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, int64_t lda, int64_t ldb);
-  void Sgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, float* A, int64_t lda, std::int64_t *ipiv,
+  void Sgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, float* A, int64_t lda, int64_t *ipiv,
               float* B, int64_t ldb, float* scratchpad, int64_t scratchpad_size);
-  void Dgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, double* A, int64_t lda, std::int64_t *ipiv,
+  void Dgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, double* A, int64_t lda, int64_t *ipiv,
               double* B, int64_t ldb, double* scratchpad, int64_t scratchpad_size);
-  void Cgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, float _Complex* A, int64_t lda, std::int64_t *ipiv,
+  void Cgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, float _Complex* A, int64_t lda, int64_t *ipiv,
               float _Complex* B, int64_t ldb, float _Complex* scratchpad, int64_t scratchpad_size);
-  void Zgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, double _Complex* A, int64_t lda, std::int64_t *ipiv,
+  void Zgetrs(Context* ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, double _Complex* A, int64_t lda, int64_t *ipiv,
               double _Complex* B, int64_t ldb, double _Complex* scratchpad, int64_t scratchpad_size);
 
   //potrf

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -78,7 +78,9 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
         std::vector<sycl::device> sycl_devices(1);
         sycl_devices[0] = ctxt->device;
-        ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl_devices);
+	// this passes in all devices to make the context since it looks like MKL needs all devices in the context
+        ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
+						   sycl::device::get_devices());
         
         if (isImmCmdList) {
             ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, ctxt->context, &ctxt->device, false, 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -78,9 +78,7 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
         std::vector<sycl::device> sycl_devices(1);
         sycl_devices[0] = ctxt->device;
-	// this passes in all devices to make the context since it looks like MKL needs all devices in the context
-        ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
-						   sycl::device::get_devices());
+        ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl_devices);
         
         if (isImmCmdList) {
             ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, ctxt->context, &ctxt->device, false, 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -9,7 +9,7 @@
 #if INTEL_MKL_VERSION >= 20250000
   #include <sycl/backend.hpp>
   // Check if ur_native_handle_t is defined
-  #ifdef ur_native_handle_t
+  #ifdef UR_API_H_INCLUDED
     #define HAS_UR_API 1
   #else
     #define HAS_UR_API 0


### PR DESCRIPTION
This is similar to https://github.com/CHIP-SPV/chipStar/pull/997.  It changes two things:

1) With the 2025.0.5 compilers on Aurora, chipStar fails to build since it does not use the correct `sycl::detail::make_platform` etc. APIs.

It currently checks whether the UR API is used by checking `ifdef ur_native_handle_t` (https://github.com/CHIP-SPV/H4I-MKLShim/blob/fc69e2cf0d6a04edee94b1d898b5cc6592da720e/src/Context.cpp#L11). However, `ifdef` doesn't work to check if a typedef is defined, so it’s not working as expected (https://stackoverflow.com/questions/6772802/in-c-c-is-there-a-directive-similar-to-ifndef-for-typedefs)

This PR changes it to ”#ifdef UR_API_H_INCLUDED” which is working on Aurora with both 2025.0.5 oneAPI SDK (which has the UR API) and 2025.0.0 (which does not have the UR API). 


2) This also changes the `std::int64_t` references to just `int64_t` since with GCC13 the compile of hipsolver will fail from:
```
In file included from /lus/flare/projects/Aurora_deployment/bertoni/chip-spv_source-20250504-release/H4I-HipSOLVER/src/hipsolver.cpp:4:
/lus/flare/projects/Aurora_deployment/bertoni/chip-spv_source-20250504-release/H4I-MKLShim/packages/include/h4i/mklshim/onemklsolver.h:130:101: error: 
      no type named 'int64_t' in namespace 'std'; did you mean simply 'int64_t'?
  130 |   ...ctxt, onemklTranspose trans, int64_t n, int64_t nrhs, float* A, int64_t lda, std::int64_t *ipiv,
      |                                                                                   ^~~~~
``` 
Was there a reason to why std::int64_t here?
