### PR TITLE
 Updates for UR API with LevelZero backend for MKL

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -78,7 +78,9 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
         std::vector<sycl::device> sycl_devices(1);
         sycl_devices[0] = ctxt->device;
-        ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false, sycl_devices);
+	// this passes in all devices to make the context since it looks like MKL needs all devices in the context
+        ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
+						   sycl::device::get_devices());
         
         if (isImmCmdList) {
             ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, ctxt->context, &ctxt->device, false, 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -83,10 +83,10 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
 						   sycl::device::get_devices());
         
         if (isImmCmdList) {
-            ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, ctxt->context, &ctxt->device, false, 
+            ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, ctxt->context, &ctxt->device, true, 
                                                   {sycl::property::queue::in_order()}, {}, sycl::backend::ext_oneapi_level_zero);
         } else {
-            ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hQueue, false, ctxt->context, &ctxt->device, false, 
+            ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hQueue, false, ctxt->context, &ctxt->device, true, 
                                                   {sycl::property::queue::in_order()}, {}, sycl::backend::ext_oneapi_level_zero);
         }
 #elif __INTEL_LLVM_COMPILER >= 20240000


### PR DESCRIPTION
This changes make_context to be created with all devices for the newer MKLs and UR API, as described in https://github.com/CHIP-SPV/chipStar/pull/998 . This is a necessary change, but after it, it looks like there are additional issues related to UR queues.

After just the make_context change, I saw a segfault for the `h4i-hipblas_basic_context_test` since it looks like if we create a new stream, UR releases the old queue. That is, if we create a stream, we can no longer use the previous default stream anymore.
I ran this through valgrind and saw: 
```
==137714== Invalid read of size 8
==137714==    at 0x3562485D: ??? (in /usr/lib64/libze_intel_gpu.so.1.6.32567)
==137714==    by 0x4A4C4AB: CHIPQueueLevel0::memCopyAsyncImpl(void*, void const*, unsigned long, hipMemcpyKind) (src/backend/Level0/CHIPBackendLevel0.cc:1458)
==137714==    by 0x4971943: chipstar::Queue::memCopy(void*, void const*, unsigned long, hipMemcpyKind) (src/CHIPBackend.cc:1609)
==137714==    by 0x49D122E: hipMemcpyInternal(void*, void const*, unsigned long, hipMemcpyKind) (src/CHIPBindings.cc:4510)
==137714==    by 0x49D12E4: hipMemcpy (src/CHIPBindings.cc:4518)
==137714==    by 0x401116: main (t.cpp:48)
==137714==  Address 0x41c0fa40 is 0 bytes inside a block of size 12,576 free'd
==137714==    at 0x483DB3F: operator delete(void*, unsigned long) (vg_replace_malloc.c:1181)
==137714==    by 0x3564D7B3: ??? (in /usr/lib64/libze_intel_gpu.so.1.6.32567)
==137714==    by 0x43713CD7: ur_queue_handle_legacy_t_::queueRelease() (in /opt/aurora/24.347.0/oneapi/compiler/2025.0/lib/libur_adapter_level_zero.so.0.10.15)
==137714==    by 0x317E8292: urQueueRelease (in /opt/aurora/24.347.0/oneapi/compiler/2025.0/lib/libur_loader.so.0.10.15)
==137714==    by 0x2F8A3A2A: sycl::_V1::detail::queue_impl::~queue_impl() (in /opt/aurora/24.347.0/oneapi/compiler/2025.0/lib/libsycl.so.8.0.0)
==137714==    by 0x5128CDC: _M_release (shared_ptr_base.h:346)
==137714==    by 0x5128CDC: ~__shared_count (shared_ptr_base.h:1071)
==137714==    by 0x5128CDC: ~__shared_ptr (shared_ptr_base.h:1524)
==137714==    by 0x5128CDC: operator= (shared_ptr_base.h:1620)
==137714==    by 0x5128CDC: operator= (shared_ptr.h:440)
==137714==    by 0x5128CDC: operator= (queue.hpp:288)
==137714==    by 0x5128CDC: H4I::MKLShim::Update(H4I::MKLShim::Context*, unsigned long const*, int) (H4I-MKLShim/src/Context.cpp:86)
==137714==    by 0x4861CCE: hipblasSetStream (H4I-HipBLAS/src/util.cpp:91)
==137714==    by 0x400EDA: main (t.cpp:40)
==137714==  Block was alloc'd at
==137714==    at 0x483A5F4: operator new(unsigned long) (vg_replace_malloc.c:487)
==137714==    by 0x35752351: ??? (in /usr/lib64/libze_intel_gpu.so.1.6.32567)
==137714==    by 0x35651E9A: ??? (in /usr/lib64/libze_intel_gpu.so.1.6.32567)
==137714==    by 0x35662E2F: ??? (in /usr/lib64/libze_intel_gpu.so.1.6.32567)
==137714==    by 0x3562430E: ??? (in /usr/lib64/libze_intel_gpu.so.1.6.32567)
==137714==    by 0x4A44660: CHIPQueueLevel0::initializeCmdListImm() (src/backend/Level0/CHIPBackendLevel0.cc:1001)
==137714==    by 0x4A43F4B: CHIPQueueLevel0::CHIPQueueLevel0(CHIPDeviceLevel0*, chipstar::QueueFlags, int) (src/backend/Level0/CHIPBackendLevel0.cc:978)
==137714==    by 0x4A57D7B: CHIPDeviceLevel0::createQueue(chipstar::QueueFlags, int) (src/backend/Level0/CHIPBackendLevel0.cc:2152)
==137714==    by 0x4968066: chipstar::Device::init() (src/CHIPBackend.cc:598)
==137714==    by 0x4A4F3A1: create (src/backend/Level0/CHIPBackendLevel0.cc:1937)
==137714==    by 0x4A4F3A1: CHIPBackendLevel0::initializeImpl() (src/backend/Level0/CHIPBackendLevel0.cc:1759)
==137714==    by 0x496F495: chipstar::Backend::initialize() (src/CHIPBackend.cc:1267)
==137714==    by 0x52895A6: __pthread_once_slow (in /lib64/libpthread-2.31.so)
==137714==
```
This says that there is an invalid read on a memCopy in the default queue, and that the memory of that queue was freed by H4I::MKLShim::Update after hipblasSetStream was called.

From talking with @TApplencourt , the issue is that we need to change make_queue to keepOwnership=true, since if we create a second queue from the same context, it will delete the previous queue.

I confirm with keepOwnership=true, I don't see the segfault, and the invalid memory read is gone from valgrind.