### PR TITLE
Implement more batched MKL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,8 @@
 
 cmake_minimum_required(VERSION 3.20)
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-result -Rno-debug-disables-optimization")
+
 # Check if this is the top-level project
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
     set(STANDALONE_BUILD ON)

--- a/include/h4i/mklshim/mklshim.h
+++ b/include/h4i/mklshim/mklshim.h
@@ -8,30 +8,6 @@
 #include "h4i/mklshim/onemklsolver.h"
 #include "h4i/mklshim/onemklblas.h"
 
-// This is a workaround to flush MKL submissions into Level-zero queue,
-// using unspecified but guaranteed behavior of intel-sycl runtime.
-// Once SYCL standard committee approves sycl::queue::flush() we will change the macro to use the same
-// FIXED: Handle OneAPI 2024.2.2 backend mismatch issue where OneMKL returns events with wrong backend
-#define __FORCE_MKL_FLUSH__(cmd)                                \
-    try {                                                       \
-        if (currentBackend == opencl) {                         \
-            try {                                               \
-                sycl::get_native<sycl::backend::opencl>(cmd);         \
-            } catch (const sycl::exception& e) {                \
-                /* OneMKL 2024.2.2 bug: status has wrong backend */ \
-                sycl::get_native<sycl::backend::ext_oneapi_level_zero>(cmd); \
-            }                                                   \
-        } else {                                                \
-            try {                                               \
-                sycl::get_native<sycl::backend::ext_oneapi_level_zero>(cmd); \
-            } catch (const sycl::exception& e) {                \
-                /* Fallback to OpenCL if Level Zero fails */   \
-                sycl::get_native<sycl::backend::opencl>(cmd);         \
-            }                                                   \
-        }                                                       \
-    } catch (const sycl::exception& e) {                        \
-        /* If both fail, skip the flush (best effort) */       \
-    }
 
 #define ONEMKL_TRY \
     if(ctxt == nullptr) { \
@@ -64,7 +40,6 @@
 
 #define ONEMKL_CATCH(msg) \
     status.wait_and_throw(); \
-    __FORCE_MKL_FLUSH__(status); \
     __CATCH__(msg)
 
 #define ONEMKL_CATCH_NO_FLUSH(msg) \

--- a/include/h4i/mklshim/mklshim.h
+++ b/include/h4i/mklshim/mklshim.h
@@ -6,6 +6,7 @@
 #include "h4i/mklshim/Context.h"
 #include "h4i/mklshim/Stream.h"
 #include "h4i/mklshim/onemklsolver.h"
+#include "h4i/mklshim/onemklblas.h"
 
 // This is a workaround to flush MKL submissions into Level-zero queue,
 // using unspecified but guaranteed behavior of intel-sycl runtime.
@@ -48,7 +49,7 @@
     try\
     {
 
-#define __CATCH__(msg) \ 
+#define __CATCH__(msg) \
     }\
     catch(sycl::exception const& e)\
     {\

--- a/include/h4i/mklshim/mklshim.h
+++ b/include/h4i/mklshim/mklshim.h
@@ -16,17 +16,17 @@
     try {                                                       \
         if (currentBackend == opencl) {                         \
             try {                                               \
-                get_native<sycl::backend::opencl>(cmd);         \
+                sycl::get_native<sycl::backend::opencl>(cmd);         \
             } catch (const sycl::exception& e) {                \
                 /* OneMKL 2024.2.2 bug: status has wrong backend */ \
-                get_native<sycl::backend::ext_oneapi_level_zero>(cmd); \
+                sycl::get_native<sycl::backend::ext_oneapi_level_zero>(cmd); \
             }                                                   \
         } else {                                                \
             try {                                               \
-                get_native<sycl::backend::ext_oneapi_level_zero>(cmd); \
+                sycl::get_native<sycl::backend::ext_oneapi_level_zero>(cmd); \
             } catch (const sycl::exception& e) {                \
                 /* Fallback to OpenCL if Level Zero fails */   \
-                get_native<sycl::backend::opencl>(cmd);         \
+                sycl::get_native<sycl::backend::opencl>(cmd);         \
             }                                                   \
         }                                                       \
     } catch (const sycl::exception& e) {                        \

--- a/include/h4i/mklshim/onemklblas.h
+++ b/include/h4i/mklshim/onemklblas.h
@@ -368,6 +368,96 @@ namespace H4I::MKLShim
               const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, float beta,
               void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count);
 
+  /** 
+   * @brief Double precision strided batch GEMM operation
+   * @param ctxt Context for the operation
+   * @param transA Transpose operation for matrix A
+   * @param transB Transpose operation for matrix B
+   * @param m Number of rows in matrix A and C
+   * @param n Number of columns in matrix B and C
+   * @param k Number of columns in matrix A and rows in matrix B
+   * @param alpha Scalar alpha
+   * @param A Input matrix A with strided batch layout
+   * @param Atype Data type of matrix A
+   * @param lda Leading dimension of matrix A
+   * @param stridea Stride between consecutive matrices in A
+   * @param B Input matrix B with strided batch layout
+   * @param Btype Data type of matrix B
+   * @param ldb Leading dimension of matrix B
+   * @param strideb Stride between consecutive matrices in B
+   * @param beta Scalar beta
+   * @param C Output matrix C with strided batch layout
+   * @param Ctype Data type of matrix C
+   * @param ldc Leading dimension of matrix C
+   * @param stridec Stride between consecutive matrices in C
+   * @param batch_count Number of matrices in the batch
+   */
+  void dGemmBatchedEx(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double alpha,
+              const void *A, onemklDatatype_t Atype, int64_t lda, int64_t stridea,
+              const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, double beta,
+              void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count);
+
+  /** 
+   * @brief Complex single precision strided batch GEMM operation
+   * @param ctxt Context for the operation
+   * @param transA Transpose operation for matrix A
+   * @param transB Transpose operation for matrix B
+   * @param m Number of rows in matrix A and C
+   * @param n Number of columns in matrix B and C
+   * @param k Number of columns in matrix A and rows in matrix B
+   * @param alpha Scalar alpha
+   * @param A Input matrix A with strided batch layout
+   * @param Atype Data type of matrix A
+   * @param lda Leading dimension of matrix A
+   * @param stridea Stride between consecutive matrices in A
+   * @param B Input matrix B with strided batch layout
+   * @param Btype Data type of matrix B
+   * @param ldb Leading dimension of matrix B
+   * @param strideb Stride between consecutive matrices in B
+   * @param beta Scalar beta
+   * @param C Output matrix C with strided batch layout
+   * @param Ctype Data type of matrix C
+   * @param ldc Leading dimension of matrix C
+   * @param stridec Stride between consecutive matrices in C
+   * @param batch_count Number of matrices in the batch
+   */
+  void cGemmBatchedEx(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, float _Complex alpha,
+              const void *A, onemklDatatype_t Atype, int64_t lda, int64_t stridea,
+              const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, float _Complex beta,
+              void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count);
+
+  /** 
+   * @brief Complex double precision strided batch GEMM operation
+   * @param ctxt Context for the operation
+   * @param transA Transpose operation for matrix A
+   * @param transB Transpose operation for matrix B
+   * @param m Number of rows in matrix A and C
+   * @param n Number of columns in matrix B and C
+   * @param k Number of columns in matrix A and rows in matrix B
+   * @param alpha Scalar alpha
+   * @param A Input matrix A with strided batch layout
+   * @param Atype Data type of matrix A
+   * @param lda Leading dimension of matrix A
+   * @param stridea Stride between consecutive matrices in A
+   * @param B Input matrix B with strided batch layout
+   * @param Btype Data type of matrix B
+   * @param ldb Leading dimension of matrix B
+   * @param strideb Stride between consecutive matrices in B
+   * @param beta Scalar beta
+   * @param C Output matrix C with strided batch layout
+   * @param Ctype Data type of matrix C
+   * @param ldc Leading dimension of matrix C
+   * @param stridec Stride between consecutive matrices in C
+   * @param batch_count Number of matrices in the batch
+   */
+  void zGemmBatchedEx(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double _Complex alpha,
+              const void *A, onemklDatatype_t Atype, int64_t lda, int64_t stridea,
+              const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, double _Complex beta,
+              void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count);
+
   void cHerk(Context* ctxt, onemklUplo uplo, onemklTranspose trans, int64_t n, int64_t k,
                   float alpha, const float _Complex* a, int64_t lda, float beta, float _Complex* c, int64_t ldc);
   void zHerk(Context* ctxt, onemklUplo uplo, onemklTranspose trans, int64_t n, int64_t k,
@@ -450,4 +540,24 @@ namespace H4I::MKLShim
   void zGeam(Context* ctxt, onemklTranspose transA, onemklTranspose transB, int64_t m, int64_t n,
                   double _Complex alpha, const double _Complex *A, int64_t lda, double _Complex beta, const double _Complex *B, int64_t ldb,
                   double _Complex *C, int64_t ldc);
+  void sGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, float alpha,
+              const float* const* A, int64_t lda,
+              const float* const* B, int64_t ldb, float beta,
+              float* const* C, int64_t ldc, int64_t batch_count);
+  void dGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double alpha,
+              const double* const* A, int64_t lda,
+              const double* const* B, int64_t ldb, double beta,
+              double* const* C, int64_t ldc, int64_t batch_count);
+  void cGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, float _Complex alpha,
+              const float _Complex* const* A, int64_t lda,
+              const float _Complex* const* B, int64_t ldb, float _Complex beta,
+              float _Complex* const* C, int64_t ldc, int64_t batch_count);
+  void zGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double _Complex alpha,
+              const double _Complex* const* A, int64_t lda,
+              const double _Complex* const* B, int64_t ldb, double _Complex beta,
+              double _Complex* const* C, int64_t ldc, int64_t batch_count);
 } // namespace

--- a/src/Common.cpp
+++ b/src/Common.cpp
@@ -28,7 +28,10 @@ namespace H4I::MKLShim
         return oneapi::mkl::side::left;
       case ONEMKL_SIDE_RIGHT:
         return oneapi::mkl::side::right;
+      case ONEMKL_SIDE_BOTH:
+        return oneapi::mkl::side::left; // Default to left for BOTH case
     }
+    return oneapi::mkl::side::left; // Default return
   }
 
   oneapi::mkl::diag convert(onemklDiag val) {
@@ -38,6 +41,7 @@ namespace H4I::MKLShim
       case ONEMKL_DIAG_UNIT:
         return oneapi::mkl::diag::unit;
     }
+    return oneapi::mkl::diag::nonunit; // Default return
   }
 
   oneapi::mkl::jobsvd convert(signed char j) {
@@ -55,6 +59,7 @@ namespace H4I::MKLShim
       case ONEMKL_JOB_NOVEC: return oneapi::mkl::job::novec;
       case ONEMKL_JOB_VEC: return oneapi::mkl::job::vec;
     }
+    return oneapi::mkl::job::novec; // Default return
   }
 
   oneapi::mkl::generate convert(onemklGen g) {
@@ -62,6 +67,7 @@ namespace H4I::MKLShim
       case ONEMKL_GEN_Q: return oneapi::mkl::generate::q;
       case ONEMKL_GEN_P: return oneapi::mkl::generate::p;
     }
+    return oneapi::mkl::generate::q; // Default return
   }
 
   MKL_VERSION get_mkl_version() {

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -78,9 +78,9 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
         std::vector<sycl::device> sycl_devices(1);
         sycl_devices[0] = ctxt->device;
-	// this passes in all devices to make the context since it looks like MKL needs all devices in the context
+	// Use the specific device from CHIP-SPV, not all system devices
         ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
-						   sycl::device::get_devices());
+						   sycl_devices);
         
         if (isImmCmdList) {
             ctxt->queue = sycl::detail::make_queue((ur_native_handle_t)hCommandList, true, ctxt->context, &ctxt->device, true, 

--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -75,9 +75,8 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         ctxt->platform = sycl::detail::make_platform((ur_native_handle_t)hDriver, sycl::backend::ext_oneapi_level_zero);
         ctxt->device = sycl::detail::make_device((ur_native_handle_t)hDevice, sycl::backend::ext_oneapi_level_zero);
 
-        // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
-        std::vector<sycl::device> sycl_devices(1);
-        sycl_devices[0] = ctxt->device;
+        std::vector<sycl::device> sycl_devices;
+        sycl_devices = ctxt->platform.get_devices();
 	// Use the specific device from CHIP-SPV, not all system devices
         ctxt->context = sycl::detail::make_context((ur_native_handle_t)hContext, {}, sycl::backend::ext_oneapi_level_zero, false,
 						   sycl_devices);
@@ -94,9 +93,8 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         ctxt->platform = sycl::ext::oneapi::level_zero::make_platform((pi_native_handle)hDriver);
         ctxt->device = sycl::ext::oneapi::level_zero::make_device(ctxt->platform, (pi_native_handle)hDevice);
 
-        // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
-        std::vector<sycl::device> sycl_devices(1);
-        sycl_devices[0] = ctxt->device;
+        std::vector<sycl::device> sycl_devices;
+        sycl_devices = ctxt->platform.get_devices();
         ctxt->context = sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle)hContext, 1);
         
         if (isImmCmdList) {
@@ -109,9 +107,8 @@ Context* Update(Context* ctxt, unsigned long const* handles, int numOfHandles) {
         ctxt->platform = sycl::ext::oneapi::level_zero::make_platform((pi_native_handle)hDriver);
         ctxt->device = sycl::ext::oneapi::level_zero::make_device(ctxt->platform, (pi_native_handle)hDevice);
 
-        // FIX ME: only 1 device is returned from CHIP-SPV's lzHandles
-        std::vector<sycl::device> sycl_devices(1);
-        sycl_devices[0] = ctxt->device;
+        std::vector<sycl::device> sycl_devices;
+        sycl_devices = ctxt->platform.get_devices();
         ctxt->context = sycl::ext::oneapi::level_zero::make_context(sycl_devices, (pi_native_handle)hContext, 1);
         
         ctxt->queue = sycl::ext::oneapi::level_zero::make_queue(ctxt->context, ctxt->device, (pi_native_handle)hQueue, 1);

--- a/src/onemklblas.cpp
+++ b/src/onemklblas.cpp
@@ -1299,6 +1299,67 @@ namespace H4I::MKLShim
     ONEMKL_CATCH("SGEMMBATCHED-EX");
   }
 
+  void dGemmBatchedEx(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double alpha,
+              const void *A, onemklDatatype_t Atype, int64_t lda, int64_t stridea,
+              const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, double beta,
+              void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    if (Atype == ONEMKL_R_64F && Btype == ONEMKL_R_64F && Ctype == ONEMKL_R_64F) {
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, tA,
+                                          tB, m, n, k, alpha, reinterpret_cast<const double *>(A),
+                                          lda, stridea, reinterpret_cast<const double *>(B), ldb, strideb, beta,
+                                          reinterpret_cast<double *>(C), ldc, stridec, batch_count);
+    }
+    ONEMKL_CATCH("DGEMMBATCHED-EX");
+  }
+
+  void cGemmBatchedEx(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, float _Complex alpha,
+              const void *A, onemklDatatype_t Atype, int64_t lda, int64_t stridea,
+              const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, float _Complex beta,
+              void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    if (Atype == ONEMKL_C_32F && Btype == ONEMKL_C_32F && Ctype == ONEMKL_C_32F) {
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, tA,
+                                          tB, m, n, k, static_cast<std::complex<float>>(alpha), 
+                                          reinterpret_cast<const std::complex<float> *>(A),
+                                          lda, stridea, reinterpret_cast<const std::complex<float> *>(B), ldb, strideb, 
+                                          static_cast<std::complex<float>>(beta),
+                                          reinterpret_cast<std::complex<float> *>(C), ldc, stridec, batch_count);
+    }
+    ONEMKL_CATCH("CGEMMBATCHED-EX");
+  }
+
+  void zGemmBatchedEx(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double _Complex alpha,
+              const void *A, onemklDatatype_t Atype, int64_t lda, int64_t stridea,
+              const void *B, onemklDatatype_t Btype, int64_t ldb, int64_t strideb, double _Complex beta,
+              void *C, onemklDatatype_t Ctype, int64_t ldc, int64_t stridec, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    if (Atype == ONEMKL_C_64F && Btype == ONEMKL_C_64F && Ctype == ONEMKL_C_64F) {
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, tA,
+                                          tB, m, n, k, static_cast<std::complex<double>>(alpha), 
+                                          reinterpret_cast<const std::complex<double> *>(A),
+                                          lda, stridea, reinterpret_cast<const std::complex<double> *>(B), ldb, strideb, 
+                                          static_cast<std::complex<double>>(beta),
+                                          reinterpret_cast<std::complex<double> *>(C), ldc, stridec, batch_count);
+    }
+    ONEMKL_CATCH("ZGEMMBATCHED-EX");
+  }
+
   void cHerk(Context* ctxt, onemklUplo uplo, onemklTranspose trans, int64_t n, int64_t k,
                 float alpha, const float _Complex* a, int64_t lda, float beta, float _Complex* c, int64_t ldc) {
     ONEMKL_TRY
@@ -1578,4 +1639,143 @@ namespace H4I::MKLShim
     ONEMKL_CATCH("zgeam");
   }
 
+  void sGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, float alpha,
+              const float* const* A, int64_t lda,
+              const float* const* B, int64_t ldb, float beta,
+              float* const* C, int64_t ldc, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    
+    // For pointer array version, parameters need to be arrays
+    std::vector<oneapi::mkl::transpose> transA_array(batch_count, tA);
+    std::vector<oneapi::mkl::transpose> transB_array(batch_count, tB);
+    std::vector<int64_t> m_array(batch_count, m);
+    std::vector<int64_t> n_array(batch_count, n);
+    std::vector<int64_t> k_array(batch_count, k);
+    std::vector<float> alpha_array(batch_count, alpha);
+    std::vector<int64_t> lda_array(batch_count, lda);
+    std::vector<int64_t> ldb_array(batch_count, ldb);
+    std::vector<float> beta_array(batch_count, beta);
+    std::vector<int64_t> ldc_array(batch_count, ldc);
+
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, 
+                                          transA_array.data(), transB_array.data(),
+                                          m_array.data(), n_array.data(), k_array.data(),
+                                          alpha_array.data(), const_cast<const float**>(A), lda_array.data(),
+                                          const_cast<const float**>(B), ldb_array.data(), beta_array.data(), const_cast<float**>(C),
+                                          ldc_array.data(), 1, &batch_count, {});
+    status.wait();
+    ONEMKL_CATCH("SGEMMBATCHED")
+  }
+
+  void dGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double alpha,
+              const double* const* A, int64_t lda,
+              const double* const* B, int64_t ldb, double beta,
+              double* const* C, int64_t ldc, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    
+    // For pointer array version, parameters need to be arrays
+    std::vector<oneapi::mkl::transpose> transA_array(batch_count, tA);
+    std::vector<oneapi::mkl::transpose> transB_array(batch_count, tB);
+    std::vector<int64_t> m_array(batch_count, m);
+    std::vector<int64_t> n_array(batch_count, n);
+    std::vector<int64_t> k_array(batch_count, k);
+    std::vector<double> alpha_array(batch_count, alpha);
+    std::vector<int64_t> lda_array(batch_count, lda);
+    std::vector<int64_t> ldb_array(batch_count, ldb);
+    std::vector<double> beta_array(batch_count, beta);
+    std::vector<int64_t> ldc_array(batch_count, ldc);
+
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, 
+                                          transA_array.data(), transB_array.data(),
+                                          m_array.data(), n_array.data(), k_array.data(),
+                                          alpha_array.data(), const_cast<const double**>(A), lda_array.data(),
+                                          const_cast<const double**>(B), ldb_array.data(), beta_array.data(), const_cast<double**>(C),
+                                          ldc_array.data(), 1, &batch_count, {});
+    status.wait();
+    ONEMKL_CATCH("DGEMMBATCHED")
+  }
+
+  void cGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, float _Complex alpha,
+              const float _Complex* const* A, int64_t lda,
+              const float _Complex* const* B, int64_t ldb, float _Complex beta,
+              float _Complex* const* C, int64_t ldc, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    
+    // For pointer array version, parameters need to be arrays
+    std::vector<oneapi::mkl::transpose> transA_array(batch_count, tA);
+    std::vector<oneapi::mkl::transpose> transB_array(batch_count, tB);
+    std::vector<int64_t> m_array(batch_count, m);
+    std::vector<int64_t> n_array(batch_count, n);
+    std::vector<int64_t> k_array(batch_count, k);
+    std::vector<std::complex<float>> alpha_array(batch_count, static_cast<std::complex<float>>(alpha));
+    std::vector<int64_t> lda_array(batch_count, lda);
+    std::vector<int64_t> ldb_array(batch_count, ldb);
+    std::vector<std::complex<float>> beta_array(batch_count, static_cast<std::complex<float>>(beta));
+    std::vector<int64_t> ldc_array(batch_count, ldc);
+
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, 
+                                          transA_array.data(), transB_array.data(),
+                                          m_array.data(), n_array.data(), k_array.data(),
+                                          alpha_array.data(), 
+                                          const_cast<const std::complex<float>**>(reinterpret_cast<const std::complex<float>* const*>(A)), 
+                                          lda_array.data(),
+                                          const_cast<const std::complex<float>**>(reinterpret_cast<const std::complex<float>* const*>(B)), 
+                                          ldb_array.data(), beta_array.data(),
+                                          const_cast<std::complex<float>**>(reinterpret_cast<std::complex<float>* const*>(C)),
+                                          ldc_array.data(), 1, &batch_count, {});
+    status.wait();
+    ONEMKL_CATCH("CGEMMBATCHED")
+  }
+
+  void zGemmBatched(Context* ctxt, onemklTranspose transA, onemklTranspose transB,
+              int64_t m, int64_t n, int64_t k, double _Complex alpha,
+              const double _Complex* const* A, int64_t lda,
+              const double _Complex* const* B, int64_t ldb, double _Complex beta,
+              double _Complex* const* C, int64_t ldc, int64_t batch_count) {
+    ONEMKL_TRY
+    sycl::event status;
+
+    auto tA = convert(transA);
+    auto tB = convert(transB);
+    
+    // For pointer array version, parameters need to be arrays
+    std::vector<oneapi::mkl::transpose> transA_array(batch_count, tA);
+    std::vector<oneapi::mkl::transpose> transB_array(batch_count, tB);
+    std::vector<int64_t> m_array(batch_count, m);
+    std::vector<int64_t> n_array(batch_count, n);
+    std::vector<int64_t> k_array(batch_count, k);
+    std::vector<std::complex<double>> alpha_array(batch_count, static_cast<std::complex<double>>(alpha));
+    std::vector<int64_t> lda_array(batch_count, lda);
+    std::vector<int64_t> ldb_array(batch_count, ldb);
+    std::vector<std::complex<double>> beta_array(batch_count, static_cast<std::complex<double>>(beta));
+    std::vector<int64_t> ldc_array(batch_count, ldc);
+
+    status = oneapi::mkl::blas::column_major::gemm_batch(ctxt->queue, 
+                                          transA_array.data(), transB_array.data(),
+                                          m_array.data(), n_array.data(), k_array.data(),
+                                          alpha_array.data(), 
+                                          const_cast<const std::complex<double>**>(reinterpret_cast<const std::complex<double>* const*>(A)), 
+                                          lda_array.data(),
+                                          const_cast<const std::complex<double>**>(reinterpret_cast<const std::complex<double>* const*>(B)), 
+                                          ldb_array.data(), beta_array.data(),
+                                          const_cast<std::complex<double>**>(reinterpret_cast<std::complex<double>* const*>(C)),
+                                          ldc_array.data(), 1, &batch_count, {});
+    status.wait();
+    ONEMKL_CATCH("ZGEMMBATCHED")
+  }
 }// end of namespace

--- a/src/onemklsolver.cpp
+++ b/src/onemklsolver.cpp
@@ -80,7 +80,7 @@ namespace H4I::MKLShim
   //orgbr/ungbr
   int64_t Sorgbr_ScPadSz(Context* ctxt,onemklGen gen, int64_t m, int64_t n, int64_t k,
                               int64_t lda) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::orgbr_scratchpad_size<float>(ctxt->queue, convert(gen), m, n, k, lda);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Sorgbr_ScPadSz")
@@ -88,7 +88,7 @@ namespace H4I::MKLShim
 
   int64_t Dorgbr_ScPadSz(Context* ctxt,onemklGen gen, int64_t m, int64_t n, int64_t k,
                               int64_t lda) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::orgbr_scratchpad_size<double>(ctxt->queue, convert(gen), m, n, k, lda);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Dorgbr_ScPadSz")
@@ -109,7 +109,7 @@ namespace H4I::MKLShim
 
   int64_t Cungbr_ScPadSz(Context* ctxt,onemklGen gen, int64_t m, int64_t n, int64_t k,
                               int64_t lda) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<float>>(ctxt->queue, convert(gen), m, n, k, lda);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Cungbr_ScPadSz")
@@ -117,7 +117,7 @@ namespace H4I::MKLShim
 
   int64_t Zungbr_ScPadSz(Context* ctxt,onemklGen gen, int64_t m, int64_t n, int64_t k,
                               int64_t lda) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<double>>(ctxt->queue, convert(gen), m, n, k, lda);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Zungbr_ScPadSz")
@@ -263,28 +263,28 @@ namespace H4I::MKLShim
   // ormqr/unmqr
   int64_t Sormqr_ScPadSz(Context* ctxt, onemklSideMode side, onemklTranspose trans, int64_t m, int64_t n, int64_t k,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::ormqr_scratchpad_size<float>(ctxt->queue, convert(side), convert(trans), m, n, k, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Sormqr_ScPadSz")
   }
   int64_t Dormqr_ScPadSz(Context* ctxt, onemklSideMode side, onemklTranspose trans, int64_t m, int64_t n, int64_t k,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::ormqr_scratchpad_size<double>(ctxt->queue, convert(side), convert(trans), m, n, k, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Dormqr_ScPadSz")
   }
   int64_t Cunmqr_ScPadSz(Context* ctxt, onemklSideMode side, onemklTranspose trans, int64_t m, int64_t n, int64_t k,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<float>>(ctxt->queue, convert(side), convert(trans), m, n, k, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Cunmqr_ScPadSz")
   }
   int64_t Zunmqr_ScPadSz(Context* ctxt, onemklSideMode side, onemklTranspose trans, int64_t m, int64_t n, int64_t k,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<double>>(ctxt->queue, convert(side), convert(trans), m, n, k, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Zunmqr_ScPadSz")
@@ -325,14 +325,14 @@ namespace H4I::MKLShim
   // ormtr/unmtr
   int64_t Sormtr_ScPadSz(Context* ctxt, onemklSideMode side, onemklUplo uplo, onemklTranspose trans, int64_t m, int64_t n,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::ormtr_scratchpad_size<float>(ctxt->queue, convert(side), convert(uplo), convert(trans), m, n, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Sormtr_ScPadSz")
   }
   int64_t Dormtr_ScPadSz(Context* ctxt, onemklSideMode side, onemklUplo uplo, onemklTranspose trans, int64_t m, int64_t n,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::ormtr_scratchpad_size<double>(ctxt->queue, convert(side), convert(uplo), convert(trans), m, n, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Dormtr_ScPadSz")
@@ -353,14 +353,14 @@ namespace H4I::MKLShim
   }
   int64_t Cunmtr_ScPadSz(Context* ctxt, onemklSideMode side, onemklUplo uplo, onemklTranspose trans, int64_t m, int64_t n,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<float>>(ctxt->queue, convert(side), convert(uplo), convert(trans), m, n, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Cunmtr_ScPadSz")
   }
   int64_t Zunmtr_ScPadSz(Context* ctxt, onemklSideMode side, onemklUplo uplo, onemklTranspose trans, int64_t m, int64_t n,
                     int64_t lda, int64_t ldc) {
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<double>>(ctxt->queue, convert(side), convert(uplo), convert(trans), m, n, lda, ldc);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Zunmtr_ScPadSz")
@@ -706,28 +706,28 @@ namespace H4I::MKLShim
   //gesvd
   int64_t Sgesvd_ScPadSz(Context* ctxt, signed char jobu, signed char jobvt, int64_t m, int64_t n,
                               int64_t lda, int64_t ldu, int64_t ldvt){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::gesvd_scratchpad_size<float>(ctxt->queue, convert(jobu), convert(jobvt), m, n, lda, ldu, ldvt);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Sgesvd_scratchpad")
   }
   int64_t Dgesvd_ScPadSz(Context* ctxt, signed char jobu, signed char jobvt, int64_t m, int64_t n,
                               int64_t lda, int64_t ldu, int64_t ldvt){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::gesvd_scratchpad_size<double>(ctxt->queue, convert(jobu), convert(jobvt), m, n, lda, ldu, ldvt);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Dgesvd_scratchpad")
   }
   int64_t Cgesvd_ScPadSz(Context* ctxt, signed char jobu, signed char jobvt, int64_t m, int64_t n,
                               int64_t lda, int64_t ldu, int64_t ldvt){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<float>>(ctxt->queue, convert(jobu), convert(jobvt), m, n, lda, ldu, ldvt);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Cgesvd_scratchpad")
   }
   int64_t Zgesvd_ScPadSz(Context* ctxt, signed char jobu, signed char jobvt, int64_t m, int64_t n,
                               int64_t lda, int64_t ldu, int64_t ldvt){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<double>>(ctxt->queue, convert(jobu), convert(jobvt), m, n, lda, ldu, ldvt);
     return size;
     ONEMKL_CATCH_NO_FLUSH("Zgesvd_scratchpad")
@@ -949,21 +949,25 @@ namespace H4I::MKLShim
   int64_t Ssygvd_ScPadSz(Context* ctxt, int64_t itype, onemklJob job, onemklUplo uplo, int64_t n, int64_t lda, int64_t ldb){
     ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::sygvd_scratchpad_size<float>(ctxt->queue, itype, convert(job), convert(uplo), n, lda, ldb);
+    return size;
     ONEMKL_CATCH_NO_FLUSH("Ssygvd_ScPadSz")
   }
   int64_t Dsygvd_ScPadSz(Context* ctxt, int64_t itype, onemklJob job, onemklUplo uplo, int64_t n, int64_t lda, int64_t ldb){
     ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::sygvd_scratchpad_size<double>(ctxt->queue, itype, convert(job), convert(uplo), n, lda, ldb);
+    return size;
     ONEMKL_CATCH_NO_FLUSH("Dsygvd_ScPadSz")
   }
   int64_t Chegvd_ScPadSz(Context* ctxt, int64_t itype, onemklJob job, onemklUplo uplo, int64_t n, int64_t lda, int64_t ldb){
     ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<float>>(ctxt->queue, itype, convert(job), convert(uplo), n, lda, ldb);
+    return size;
     ONEMKL_CATCH_NO_FLUSH("Chegvd_ScPadSz")
   }
   int64_t Zhegvd_ScPadSz(Context* ctxt, int64_t itype, onemklJob job, onemklUplo uplo, int64_t n, int64_t lda, int64_t ldb){
     ONEMKL_TRY_RETURN(-1)
     auto size = oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<double>>(ctxt->queue, itype, convert(job), convert(uplo), n, lda, ldb);
+    return size;
     ONEMKL_CATCH_NO_FLUSH("Zhegvd_ScPadSz")
   }
   void Ssygvd(Context* ctxt, int64_t itype, onemklJob job, onemklUplo uplo, int64_t n, float* A, int64_t lda, float* B, int64_t ldb, float* W,
@@ -1152,7 +1156,7 @@ namespace H4I::MKLShim
   // getrs_batch
   int64_t Sgetrs_batch_ScPadSz(Context* ctxt, int64_t group_count, onemklTranspose* trans, int64_t* n, int64_t* nrhs,
                                 int64_t* lda, int64_t* ldb, int64_t* group_sizes){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     std::vector<oneapi::mkl::transpose> trans_vec(group_count);
     for(int64_t i = 0; i < group_count; ++i) {
       trans_vec[i] = convert(trans[i]);
@@ -1165,7 +1169,7 @@ namespace H4I::MKLShim
 
   int64_t Dgetrs_batch_ScPadSz(Context* ctxt, int64_t group_count, onemklTranspose* trans, int64_t* n, int64_t* nrhs,
                                 int64_t* lda, int64_t* ldb, int64_t* group_sizes){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     std::vector<oneapi::mkl::transpose> trans_vec(group_count);
     for(int64_t i = 0; i < group_count; ++i) {
       trans_vec[i] = convert(trans[i]);
@@ -1178,7 +1182,7 @@ namespace H4I::MKLShim
 
   int64_t Cgetrs_batch_ScPadSz(Context* ctxt, int64_t group_count, onemklTranspose* trans, int64_t* n, int64_t* nrhs,
                                 int64_t* lda, int64_t* ldb, int64_t* group_sizes){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     std::vector<oneapi::mkl::transpose> trans_vec(group_count);
     for(int64_t i = 0; i < group_count; ++i) {
       trans_vec[i] = convert(trans[i]);
@@ -1191,7 +1195,7 @@ namespace H4I::MKLShim
 
   int64_t Zgetrs_batch_ScPadSz(Context* ctxt, int64_t group_count, onemklTranspose* trans, int64_t* n, int64_t* nrhs,
                                 int64_t* lda, int64_t* ldb, int64_t* group_sizes){
-    ONEMKL_TRY
+    ONEMKL_TRY_RETURN(-1)
     std::vector<oneapi::mkl::transpose> trans_vec(group_count);
     for(int64_t i = 0; i < group_count; ++i) {
       trans_vec[i] = convert(trans[i]);

--- a/test/batch_correctness_test.cpp
+++ b/test/batch_correctness_test.cpp
@@ -580,6 +580,732 @@ bool testDgetrfBatchVsNonBatch(H4I::MKLShim::Context* context) {
     }
 }
 
+// Test dGemmBatchedEx correctness  
+bool testDGemmBatchedExCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing dGemmBatchedEx correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const double alpha = 1.0, beta = 0.0;
+    
+    // Calculate strides
+    const int64_t stride_a = lda * k;
+    const int64_t stride_b = ldb * n;
+    const int64_t stride_c = ldc * n;
+    
+    // Create test data
+    std::vector<double> A_host(batch_count * stride_a);
+    std::vector<double> B_host(batch_count * stride_b);
+    std::vector<double> C_host(batch_count * stride_c, 0.0);
+    std::vector<double> C_expected(batch_count * stride_c, 0.0);
+    
+    // Initialize with simple values for manual verification
+    // A = [[1,2],[3,4]], B = [[2,0],[1,2]] for first batch
+    // A = [[2,3],[4,5]], B = [[2,0],[1,2]] for second batch
+    for (int64_t b = 0; b < batch_count; ++b) {
+        // Matrix A (column-major)
+        A_host[b * stride_a + 0] = 1.0 + b; // A(0,0) 
+        A_host[b * stride_a + 1] = 3.0 + b; // A(1,0)
+        A_host[b * stride_a + 2] = 2.0 + b; // A(0,1)
+        A_host[b * stride_a + 3] = 4.0 + b; // A(1,1)
+        
+        // Matrix B (column-major)
+        B_host[b * stride_b + 0] = 2.0; // B(0,0)
+        B_host[b * stride_b + 1] = 1.0; // B(1,0)
+        B_host[b * stride_b + 2] = 0.0; // B(0,1)
+        B_host[b * stride_b + 3] = 2.0; // B(1,1)
+        
+        // Expected C = A * B (manually calculated, column-major)
+        // C(0,0) = A(0,0)*B(0,0) + A(0,1)*B(1,0) = (1+b)*2 + (2+b)*1 = 4+3b
+        // C(1,0) = A(1,0)*B(0,0) + A(1,1)*B(1,0) = (3+b)*2 + (4+b)*1 = 10+3b
+        // C(0,1) = A(0,0)*B(0,1) + A(0,1)*B(1,1) = (1+b)*0 + (2+b)*2 = 4+2b
+        // C(1,1) = A(1,0)*B(0,1) + A(1,1)*B(1,1) = (3+b)*0 + (4+b)*2 = 8+2b
+        C_expected[b * stride_c + 0] = 4.0 + 3.0 * b; // C(0,0)
+        C_expected[b * stride_c + 1] = 10.0 + 3.0 * b; // C(1,0)
+        C_expected[b * stride_c + 2] = 4.0 + 2.0 * b; // C(0,1)
+        C_expected[b * stride_c + 3] = 8.0 + 2.0 * b; // C(1,1)
+    }
+    
+    // Allocate device memory
+    double* A_dev = nullptr;
+    double* B_dev = nullptr;
+    double* C_dev = nullptr;
+    
+    if (hipMalloc(&A_dev, A_host.size() * sizeof(double)) != hipSuccess ||
+        hipMalloc(&B_dev, B_host.size() * sizeof(double)) != hipSuccess ||
+        hipMalloc(&C_dev, C_host.size() * sizeof(double)) != hipSuccess) {
+        std::cout << "dGemmBatchedEx: Memory allocation failed" << std::endl;
+        return false;
+    }
+    
+    // Copy to device
+    hipMemcpy(A_dev, A_host.data(), A_host.size() * sizeof(double), hipMemcpyHostToDevice);
+    hipMemcpy(B_dev, B_host.data(), B_host.size() * sizeof(double), hipMemcpyHostToDevice);
+    hipMemcpy(C_dev, C_host.data(), C_host.size() * sizeof(double), hipMemcpyHostToDevice);
+    
+    // Execute batch GEMM
+    H4I::MKLShim::dGemmBatchedEx(context, 
+                                 H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, 
+                                 H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                                 m, n, k, alpha,
+                                 A_dev, H4I::MKLShim::ONEMKL_R_64F, lda, stride_a,
+                                 B_dev, H4I::MKLShim::ONEMKL_R_64F, ldb, stride_b, 
+                                 beta, C_dev, H4I::MKLShim::ONEMKL_R_64F, ldc, stride_c, 
+                                 batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy result back
+    hipMemcpy(C_host.data(), C_dev, C_host.size() * sizeof(double), hipMemcpyDeviceToHost);
+    
+    // Compare with expected results
+    bool passed = true;
+    const double tolerance = 1e-12;
+    
+    for (size_t i = 0; i < C_host.size(); ++i) {
+        if (std::abs(C_host[i] - C_expected[i]) > tolerance) {
+            std::cout << "dGemmBatchedEx: Mismatch at index " << i << ": got " << C_host[i] 
+                      << ", expected " << C_expected[i] << std::endl;
+            passed = false;
+        }
+    }
+    
+    // Cleanup
+    if (A_dev) hipFree(A_dev);
+    if (B_dev) hipFree(B_dev);
+    if (C_dev) hipFree(C_dev);
+    
+    if (passed) {
+        std::cout << "dGemmBatchedEx correctness: PASSED" << std::endl;
+    } else {
+        std::cout << "dGemmBatchedEx correctness: FAILED" << std::endl;
+    }
+    
+    return passed;
+}
+
+// Test cGemmBatchedEx correctness  
+bool testCGemmBatchedExCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing cGemmBatchedEx correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const float _Complex alpha = 1.0f + 0.0fi, beta = 0.0f + 0.0fi;
+    
+    // Calculate strides
+    const int64_t stride_a = lda * k;
+    const int64_t stride_b = ldb * n;
+    const int64_t stride_c = ldc * n;
+    
+    // Create test data
+    std::vector<float _Complex> A_host(batch_count * stride_a);
+    std::vector<float _Complex> B_host(batch_count * stride_b);
+    std::vector<float _Complex> C_host(batch_count * stride_c, 0.0f + 0.0fi);
+    std::vector<float _Complex> C_expected(batch_count * stride_c);
+    
+    // Initialize test matrices
+    // Batch 0: A = [[1+i, 2], [3, 4+i]], B = [[1, 2+i], [3+i, 4]]
+    A_host[0] = 1.0f + 1.0f * I; A_host[1] = 3.0f + 0.0f * I;
+    A_host[2] = 2.0f + 0.0f * I; A_host[3] = 4.0f + 1.0f * I;
+    B_host[0] = 1.0f + 0.0f * I; B_host[1] = 3.0f + 1.0f * I;
+    B_host[2] = 2.0f + 1.0f * I; B_host[3] = 4.0f + 0.0f * I;
+    
+    // Batch 1: A = [[2+i, 1], [4, 3+i]], B = [[2, 1+i], [4+i, 3]]
+    A_host[4] = 2.0f + 1.0f * I; A_host[5] = 4.0f + 0.0f * I;
+    A_host[6] = 1.0f + 0.0f * I; A_host[7] = 3.0f + 1.0f * I;
+    B_host[4] = 2.0f + 0.0f * I; B_host[5] = 4.0f + 1.0f * I;
+    B_host[6] = 1.0f + 1.0f * I; B_host[7] = 3.0f + 0.0f * I;
+    
+    // Calculate expected results manually for C = A * B
+    // Batch 0: Expected results
+    C_expected[0] = (1.0f + 1.0f * I) * (1.0f + 0.0f * I) + (2.0f + 0.0f * I) * (3.0f + 1.0f * I); // C[0,0]
+    C_expected[1] = (3.0f + 0.0f * I) * (1.0f + 0.0f * I) + (4.0f + 1.0f * I) * (3.0f + 1.0f * I); // C[1,0]
+    C_expected[2] = (1.0f + 1.0f * I) * (2.0f + 1.0f * I) + (2.0f + 0.0f * I) * (4.0f + 0.0f * I); // C[0,1]
+    C_expected[3] = (3.0f + 0.0f * I) * (2.0f + 1.0f * I) + (4.0f + 1.0f * I) * (4.0f + 0.0f * I); // C[1,1]
+    
+    // Batch 1: Expected results
+    C_expected[4] = (2.0f + 1.0f * I) * (2.0f + 0.0f * I) + (1.0f + 0.0f * I) * (4.0f + 1.0f * I); // C[0,0]
+    C_expected[5] = (4.0f + 0.0f * I) * (2.0f + 0.0f * I) + (3.0f + 1.0f * I) * (4.0f + 1.0f * I); // C[1,0]
+    C_expected[6] = (2.0f + 1.0f * I) * (1.0f + 1.0f * I) + (1.0f + 0.0f * I) * (3.0f + 0.0f * I); // C[0,1]
+    C_expected[7] = (4.0f + 0.0f * I) * (1.0f + 1.0f * I) + (3.0f + 1.0f * I) * (3.0f + 0.0f * I); // C[1,1]
+    
+    // Allocate device memory
+    float _Complex *A_dev, *B_dev, *C_dev;
+    hipMalloc(&A_dev, sizeof(float _Complex) * batch_count * stride_a);
+    hipMalloc(&B_dev, sizeof(float _Complex) * batch_count * stride_b);
+    hipMalloc(&C_dev, sizeof(float _Complex) * batch_count * stride_c);
+    
+    // Copy data to device
+    hipMemcpy(A_dev, A_host.data(), sizeof(float _Complex) * batch_count * stride_a, hipMemcpyHostToDevice);
+    hipMemcpy(B_dev, B_host.data(), sizeof(float _Complex) * batch_count * stride_b, hipMemcpyHostToDevice);
+    hipMemcpy(C_dev, C_host.data(), sizeof(float _Complex) * batch_count * stride_c, hipMemcpyHostToDevice);
+    
+    // Execute cGemmBatchedEx
+    H4I::MKLShim::cGemmBatchedEx(context, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                                 m, n, k, alpha,
+                                 A_dev, H4I::MKLShim::ONEMKL_C_32F, lda, stride_a,
+                                 B_dev, H4I::MKLShim::ONEMKL_C_32F, ldb, stride_b, beta,
+                                 C_dev, H4I::MKLShim::ONEMKL_C_32F, ldc, stride_c, batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy results back to host
+    hipMemcpy(C_host.data(), C_dev, sizeof(float _Complex) * batch_count * stride_c, hipMemcpyDeviceToHost);
+    
+    // Verify results
+    bool passed = true;
+    const float tolerance = 1e-5f;
+    for (int64_t i = 0; i < batch_count * stride_c; i++) {
+        float real_diff = fabsf(crealf(C_host[i]) - crealf(C_expected[i]));
+        float imag_diff = fabsf(cimagf(C_host[i]) - cimagf(C_expected[i]));
+        if (real_diff > tolerance || imag_diff > tolerance) {
+            std::cout << "Mismatch at index " << i << ": got (" << crealf(C_host[i]) << "," << cimagf(C_host[i]) 
+                      << "), expected (" << crealf(C_expected[i]) << "," << cimagf(C_expected[i]) << ")" << std::endl;
+            passed = false;
+        }
+    }
+    
+    // Cleanup
+    hipFree(A_dev);
+    hipFree(B_dev);
+    hipFree(C_dev);
+    
+    std::cout << "cGemmBatchedEx test: " << (passed ? "PASSED" : "FAILED") << std::endl;
+    return passed;
+}
+
+// Test zGemmBatchedEx correctness  
+bool testZGemmBatchedExCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing zGemmBatchedEx correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const double _Complex alpha = 1.0 + 0.0 * I, beta = 0.0 + 0.0 * I;
+    
+    // Calculate strides
+    const int64_t stride_a = lda * k;
+    const int64_t stride_b = ldb * n;
+    const int64_t stride_c = ldc * n;
+    
+    // Create test data
+    std::vector<double _Complex> A_host(batch_count * stride_a);
+    std::vector<double _Complex> B_host(batch_count * stride_b);
+    std::vector<double _Complex> C_host(batch_count * stride_c, 0.0 + 0.0 * I);
+    std::vector<double _Complex> C_expected(batch_count * stride_c);
+    
+    // Initialize with simple values for manual verification
+    for (int batch = 0; batch < batch_count; batch++) {
+        for (int i = 0; i < stride_a; i++) {
+            A_host[batch * stride_a + i] = (batch + 1.0) + (i + 1.0) * I;
+        }
+        for (int i = 0; i < stride_b; i++) {
+            B_host[batch * stride_b + i] = (batch + 2.0) + (i + 2.0) * I;
+        }
+    }
+    
+    // Calculate expected results manually
+    // For 2x2 matrices: C = A * B
+    for (int batch = 0; batch < batch_count; batch++) {
+        const double _Complex* A = &A_host[batch * stride_a];
+        const double _Complex* B = &B_host[batch * stride_b];
+        double _Complex* C = &C_expected[batch * stride_c];
+        
+        // Manual matrix multiplication for 2x2 case
+        C[0] = A[0] * B[0] + A[2] * B[1];  // C[0,0]
+        C[1] = A[1] * B[0] + A[3] * B[1];  // C[1,0]
+        C[2] = A[0] * B[2] + A[2] * B[3];  // C[0,1]
+        C[3] = A[1] * B[2] + A[3] * B[3];  // C[1,1]
+    }
+    
+    // Allocate device memory
+    void *A_dev, *B_dev, *C_dev;
+    hipMalloc(&A_dev, batch_count * stride_a * sizeof(double _Complex));
+    hipMalloc(&B_dev, batch_count * stride_b * sizeof(double _Complex));
+    hipMalloc(&C_dev, batch_count * stride_c * sizeof(double _Complex));
+    
+    // Copy to device
+    hipMemcpy(A_dev, A_host.data(), batch_count * stride_a * sizeof(double _Complex), hipMemcpyHostToDevice);
+    hipMemcpy(B_dev, B_host.data(), batch_count * stride_b * sizeof(double _Complex), hipMemcpyHostToDevice);
+    hipMemcpy(C_dev, C_host.data(), batch_count * stride_c * sizeof(double _Complex), hipMemcpyHostToDevice);
+    
+    // Execute zGemmBatchedEx
+    H4I::MKLShim::zGemmBatchedEx(context, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                                 m, n, k, alpha,
+                                 A_dev, H4I::MKLShim::ONEMKL_C_64F, lda, stride_a,
+                                 B_dev, H4I::MKLShim::ONEMKL_C_64F, ldb, stride_b, beta,
+                                 C_dev, H4I::MKLShim::ONEMKL_C_64F, ldc, stride_c, batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy result back
+    std::vector<double _Complex> C_result(batch_count * stride_c);
+    hipMemcpy(C_result.data(), C_dev, batch_count * stride_c * sizeof(double _Complex), hipMemcpyDeviceToHost);
+    
+    // Cleanup
+    hipFree(A_dev);
+    hipFree(B_dev);
+    hipFree(C_dev);
+    
+    // Verify results
+    const double tolerance = 1e-12;
+    bool success = true;
+    for (int i = 0; i < batch_count * stride_c; i++) {
+        if (fabs(creal(C_result[i]) - creal(C_expected[i])) > tolerance ||
+            fabs(cimag(C_result[i]) - cimag(C_expected[i])) > tolerance) {
+            std::cout << "Mismatch at index " << i << ": expected (" << creal(C_expected[i]) << ", " << cimag(C_expected[i]) 
+                      << "), got (" << creal(C_result[i]) << ", " << cimag(C_result[i]) << ")" << std::endl;
+            success = false;
+        }
+    }
+    
+    if (success) {
+        std::cout << "zGemmBatchedEx test PASSED" << std::endl;
+    } else {
+        std::cout << "zGemmBatchedEx test FAILED" << std::endl;
+    }
+    
+    return success;
+}
+
+// Test sGemmBatched correctness  
+bool testSGemmBatchedCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing sGemmBatched correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const float alpha = 1.0f, beta = 0.0f;
+    
+    // Create test data
+    std::vector<float> A_host(batch_count * lda * k);
+    std::vector<float> B_host(batch_count * ldb * n);
+    std::vector<float> C_host(batch_count * ldc * n, 0.0f);
+    std::vector<float> C_expected(batch_count * ldc * n, 0.0f);
+    
+    // Initialize with simple values for manual verification
+    for (int batch = 0; batch < batch_count; batch++) {
+        for (int i = 0; i < lda * k; i++) {
+            A_host[batch * lda * k + i] = (batch + 1) * (i + 1);
+        }
+        for (int i = 0; i < ldb * n; i++) {
+            B_host[batch * ldb * n + i] = (batch + 2) * (i + 1);
+        }
+    }
+    
+    // Calculate expected results manually
+    // For 2x2 matrices: C = A * B
+    for (int batch = 0; batch < batch_count; batch++) {
+        const float* A = &A_host[batch * lda * k];
+        const float* B = &B_host[batch * ldb * n];
+        float* C = &C_expected[batch * ldc * n];
+        
+        // Manual matrix multiplication for 2x2 case
+        C[0] = A[0] * B[0] + A[2] * B[1];  // C[0,0]
+        C[1] = A[1] * B[0] + A[3] * B[1];  // C[1,0]
+        C[2] = A[0] * B[2] + A[2] * B[3];  // C[0,1]
+        C[3] = A[1] * B[2] + A[3] * B[3];  // C[1,1]
+    }
+    
+    // Allocate device memory for matrices
+    std::vector<void*> A_dev_ptrs(batch_count), B_dev_ptrs(batch_count), C_dev_ptrs(batch_count);
+    for (int i = 0; i < batch_count; i++) {
+        hipMalloc(&A_dev_ptrs[i], lda * k * sizeof(float));
+        hipMalloc(&B_dev_ptrs[i], ldb * n * sizeof(float));
+        hipMalloc(&C_dev_ptrs[i], ldc * n * sizeof(float));
+        
+        hipMemcpy(A_dev_ptrs[i], &A_host[i * lda * k], lda * k * sizeof(float), hipMemcpyHostToDevice);
+        hipMemcpy(B_dev_ptrs[i], &B_host[i * ldb * n], ldb * n * sizeof(float), hipMemcpyHostToDevice);
+        hipMemcpy(C_dev_ptrs[i], &C_host[i * ldc * n], ldc * n * sizeof(float), hipMemcpyHostToDevice);
+    }
+    
+    // Allocate device memory for pointer arrays
+    void **A_dev_ptr_array, **B_dev_ptr_array, **C_dev_ptr_array;
+    hipMalloc(&A_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&B_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&C_dev_ptr_array, batch_count * sizeof(void*));
+    
+    // Copy pointer arrays to device
+    hipMemcpy(A_dev_ptr_array, A_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(B_dev_ptr_array, B_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(C_dev_ptr_array, C_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    
+    // Execute sGemmBatched
+    H4I::MKLShim::sGemmBatched(context, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                               m, n, k, alpha,
+                               reinterpret_cast<const float* const*>(A_dev_ptr_array), lda,
+                               reinterpret_cast<const float* const*>(B_dev_ptr_array), ldb, beta,
+                               reinterpret_cast<float* const*>(C_dev_ptr_array), ldc, batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy results back
+    std::vector<float> C_result(batch_count * ldc * n);
+    for (int i = 0; i < batch_count; i++) {
+        hipMemcpy(&C_result[i * ldc * n], C_dev_ptrs[i], ldc * n * sizeof(float), hipMemcpyDeviceToHost);
+    }
+    
+    // Cleanup
+    for (int i = 0; i < batch_count; i++) {
+        hipFree(A_dev_ptrs[i]);
+        hipFree(B_dev_ptrs[i]);
+        hipFree(C_dev_ptrs[i]);
+    }
+    hipFree(A_dev_ptr_array);
+    hipFree(B_dev_ptr_array);
+    hipFree(C_dev_ptr_array);
+    
+    // Verify results
+    const float tolerance = 1e-5f;
+    bool success = true;
+    for (int i = 0; i < batch_count * ldc * n; i++) {
+        if (fabs(C_result[i] - C_expected[i]) > tolerance) {
+            std::cout << "Mismatch at index " << i << ": expected " << C_expected[i] 
+                      << ", got " << C_result[i] << std::endl;
+            success = false;
+        }
+    }
+    
+    if (success) {
+        std::cout << "sGemmBatched test PASSED" << std::endl;
+    } else {
+        std::cout << "sGemmBatched test FAILED" << std::endl;
+    }
+    
+    return success;
+}
+
+// Test dGemmBatched correctness  
+bool testDGemmBatchedCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing dGemmBatched correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const double alpha = 1.0, beta = 0.0;
+    
+    // Create test data
+    std::vector<double> A_host(batch_count * lda * k);
+    std::vector<double> B_host(batch_count * ldb * n);
+    std::vector<double> C_host(batch_count * ldc * n, 0.0);
+    std::vector<double> C_expected(batch_count * ldc * n, 0.0);
+    
+    // Initialize with simple values for manual verification
+    for (int batch = 0; batch < batch_count; batch++) {
+        for (int i = 0; i < lda * k; i++) {
+            A_host[batch * lda * k + i] = (batch + 1) * (i + 1);
+        }
+        for (int i = 0; i < ldb * n; i++) {
+            B_host[batch * ldb * n + i] = (batch + 2) * (i + 1);
+        }
+    }
+    
+    // Calculate expected results manually
+    // For 2x2 matrices: C = A * B
+    for (int batch = 0; batch < batch_count; batch++) {
+        const double* A = &A_host[batch * lda * k];
+        const double* B = &B_host[batch * ldb * n];
+        double* C = &C_expected[batch * ldc * n];
+        
+        // Manual matrix multiplication for 2x2 case
+        C[0] = A[0] * B[0] + A[2] * B[1];  // C[0,0]
+        C[1] = A[1] * B[0] + A[3] * B[1];  // C[1,0]
+        C[2] = A[0] * B[2] + A[2] * B[3];  // C[0,1]
+        C[3] = A[1] * B[2] + A[3] * B[3];  // C[1,1]
+    }
+    
+    // Allocate device memory for matrices
+    std::vector<void*> A_dev_ptrs(batch_count), B_dev_ptrs(batch_count), C_dev_ptrs(batch_count);
+    for (int i = 0; i < batch_count; i++) {
+        hipMalloc(&A_dev_ptrs[i], lda * k * sizeof(double));
+        hipMalloc(&B_dev_ptrs[i], ldb * n * sizeof(double));
+        hipMalloc(&C_dev_ptrs[i], ldc * n * sizeof(double));
+        
+        hipMemcpy(A_dev_ptrs[i], &A_host[i * lda * k], lda * k * sizeof(double), hipMemcpyHostToDevice);
+        hipMemcpy(B_dev_ptrs[i], &B_host[i * ldb * n], ldb * n * sizeof(double), hipMemcpyHostToDevice);
+        hipMemcpy(C_dev_ptrs[i], &C_host[i * ldc * n], ldc * n * sizeof(double), hipMemcpyHostToDevice);
+    }
+    
+    // Allocate device memory for pointer arrays
+    void **A_dev_ptr_array, **B_dev_ptr_array, **C_dev_ptr_array;
+    hipMalloc(&A_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&B_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&C_dev_ptr_array, batch_count * sizeof(void*));
+    
+    // Copy pointer arrays to device
+    hipMemcpy(A_dev_ptr_array, A_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(B_dev_ptr_array, B_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(C_dev_ptr_array, C_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    
+    // Execute dGemmBatched
+    H4I::MKLShim::dGemmBatched(context, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                               m, n, k, alpha,
+                               reinterpret_cast<const double* const*>(A_dev_ptr_array), lda,
+                               reinterpret_cast<const double* const*>(B_dev_ptr_array), ldb, beta,
+                               reinterpret_cast<double* const*>(C_dev_ptr_array), ldc, batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy results back
+    std::vector<double> C_result(batch_count * ldc * n);
+    for (int i = 0; i < batch_count; i++) {
+        hipMemcpy(&C_result[i * ldc * n], C_dev_ptrs[i], ldc * n * sizeof(double), hipMemcpyDeviceToHost);
+    }
+    
+    // Cleanup
+    for (int i = 0; i < batch_count; i++) {
+        hipFree(A_dev_ptrs[i]);
+        hipFree(B_dev_ptrs[i]);
+        hipFree(C_dev_ptrs[i]);
+    }
+    hipFree(A_dev_ptr_array);
+    hipFree(B_dev_ptr_array);
+    hipFree(C_dev_ptr_array);
+    
+    // Verify results
+    const double tolerance = 1e-12;
+    bool success = true;
+    for (int i = 0; i < batch_count * ldc * n; i++) {
+        if (fabs(C_result[i] - C_expected[i]) > tolerance) {
+            std::cout << "Mismatch at index " << i << ": expected " << C_expected[i] 
+                      << ", got " << C_result[i] << std::endl;
+            success = false;
+        }
+    }
+    
+    if (success) {
+        std::cout << "dGemmBatched test PASSED" << std::endl;
+    } else {
+        std::cout << "dGemmBatched test FAILED" << std::endl;
+    }
+    
+    return success;
+}
+
+// Test cGemmBatched correctness  
+bool testCGemmBatchedCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing cGemmBatched correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const float _Complex alpha = 1.0f + 0.0f * I, beta = 0.0f + 0.0f * I;
+    
+    // Create test data
+    std::vector<float _Complex> A_host(batch_count * lda * k);
+    std::vector<float _Complex> B_host(batch_count * ldb * n);
+    std::vector<float _Complex> C_host(batch_count * ldc * n, 0.0f + 0.0f * I);
+    std::vector<float _Complex> C_expected(batch_count * ldc * n, 0.0f + 0.0f * I);
+    
+    // Initialize with simple values for manual verification
+    for (int batch = 0; batch < batch_count; batch++) {
+        for (int i = 0; i < lda * k; i++) {
+            A_host[batch * lda * k + i] = (batch + 1.0f) + (i + 1.0f) * I;
+        }
+        for (int i = 0; i < ldb * n; i++) {
+            B_host[batch * ldb * n + i] = (batch + 2.0f) + (i + 2.0f) * I;
+        }
+    }
+    
+    // Calculate expected results manually
+    // For 2x2 matrices: C = A * B
+    for (int batch = 0; batch < batch_count; batch++) {
+        const float _Complex* A = &A_host[batch * lda * k];
+        const float _Complex* B = &B_host[batch * ldb * n];
+        float _Complex* C = &C_expected[batch * ldc * n];
+        
+        // Manual matrix multiplication for 2x2 case
+        C[0] = A[0] * B[0] + A[2] * B[1];  // C[0,0]
+        C[1] = A[1] * B[0] + A[3] * B[1];  // C[1,0]
+        C[2] = A[0] * B[2] + A[2] * B[3];  // C[0,1]
+        C[3] = A[1] * B[2] + A[3] * B[3];  // C[1,1]
+    }
+    
+    // Allocate device memory for matrices
+    std::vector<void*> A_dev_ptrs(batch_count), B_dev_ptrs(batch_count), C_dev_ptrs(batch_count);
+    for (int i = 0; i < batch_count; i++) {
+        hipMalloc(&A_dev_ptrs[i], lda * k * sizeof(float _Complex));
+        hipMalloc(&B_dev_ptrs[i], ldb * n * sizeof(float _Complex));
+        hipMalloc(&C_dev_ptrs[i], ldc * n * sizeof(float _Complex));
+        
+        hipMemcpy(A_dev_ptrs[i], &A_host[i * lda * k], lda * k * sizeof(float _Complex), hipMemcpyHostToDevice);
+        hipMemcpy(B_dev_ptrs[i], &B_host[i * ldb * n], ldb * n * sizeof(float _Complex), hipMemcpyHostToDevice);
+        hipMemcpy(C_dev_ptrs[i], &C_host[i * ldc * n], ldc * n * sizeof(float _Complex), hipMemcpyHostToDevice);
+    }
+    
+    // Allocate device memory for pointer arrays
+    void **A_dev_ptr_array, **B_dev_ptr_array, **C_dev_ptr_array;
+    hipMalloc(&A_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&B_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&C_dev_ptr_array, batch_count * sizeof(void*));
+    
+    // Copy pointer arrays to device
+    hipMemcpy(A_dev_ptr_array, A_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(B_dev_ptr_array, B_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(C_dev_ptr_array, C_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    
+    // Execute cGemmBatched
+    H4I::MKLShim::cGemmBatched(context, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                               m, n, k, alpha,
+                               reinterpret_cast<const float _Complex* const*>(A_dev_ptr_array), lda,
+                               reinterpret_cast<const float _Complex* const*>(B_dev_ptr_array), ldb, beta,
+                               reinterpret_cast<float _Complex* const*>(C_dev_ptr_array), ldc, batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy results back
+    std::vector<float _Complex> C_result(batch_count * ldc * n);
+    for (int i = 0; i < batch_count; i++) {
+        hipMemcpy(&C_result[i * ldc * n], C_dev_ptrs[i], ldc * n * sizeof(float _Complex), hipMemcpyDeviceToHost);
+    }
+    
+    // Cleanup
+    for (int i = 0; i < batch_count; i++) {
+        hipFree(A_dev_ptrs[i]);
+        hipFree(B_dev_ptrs[i]);
+        hipFree(C_dev_ptrs[i]);
+    }
+    hipFree(A_dev_ptr_array);
+    hipFree(B_dev_ptr_array);
+    hipFree(C_dev_ptr_array);
+    
+    // Verify results
+    const float tolerance = 1e-5f;
+    bool success = true;
+    for (int i = 0; i < batch_count * ldc * n; i++) {
+        float real_diff = fabsf(crealf(C_result[i]) - crealf(C_expected[i]));
+        float imag_diff = fabsf(cimagf(C_result[i]) - cimagf(C_expected[i]));
+        if (real_diff > tolerance || imag_diff > tolerance) {
+            std::cout << "Mismatch at index " << i << ": expected (" 
+                      << crealf(C_expected[i]) << ", " << cimagf(C_expected[i]) 
+                      << "), got (" << crealf(C_result[i]) << ", " << cimagf(C_result[i]) 
+                      << ")" << std::endl;
+            success = false;
+        }
+    }
+    
+    if (success) {
+        std::cout << "cGemmBatched test PASSED" << std::endl;
+    } else {
+        std::cout << "cGemmBatched test FAILED" << std::endl;
+    }
+    
+    return success;
+}
+
+// Test zGemmBatched correctness  
+bool testZGemmBatchedCorrectness(H4I::MKLShim::Context* context) {
+    std::cout << "Testing zGemmBatched correctness..." << std::endl;
+    
+    const int64_t m = 2, n = 2, k = 2;
+    const int64_t lda = m, ldb = k, ldc = m;
+    const int64_t batch_count = 2;
+    const double _Complex alpha = 1.0 + 0.0 * I, beta = 0.0 + 0.0 * I;
+    
+    // Create test data
+    std::vector<double _Complex> A_host(batch_count * lda * k);
+    std::vector<double _Complex> B_host(batch_count * ldb * n);
+    std::vector<double _Complex> C_host(batch_count * ldc * n, 0.0 + 0.0 * I);
+    std::vector<double _Complex> C_expected(batch_count * ldc * n, 0.0 + 0.0 * I);
+    
+    // Initialize with simple values for manual verification
+    for (int batch = 0; batch < batch_count; batch++) {
+        for (int i = 0; i < lda * k; i++) {
+            A_host[batch * lda * k + i] = (batch + 1.0) + (i + 1.0) * I;
+        }
+        for (int i = 0; i < ldb * n; i++) {
+            B_host[batch * ldb * n + i] = (batch + 2.0) + (i + 2.0) * I;
+        }
+    }
+    
+    // Calculate expected results manually
+    // For 2x2 matrices: C = A * B
+    for (int batch = 0; batch < batch_count; batch++) {
+        const double _Complex* A = &A_host[batch * lda * k];
+        const double _Complex* B = &B_host[batch * ldb * n];
+        double _Complex* C = &C_expected[batch * ldc * n];
+        
+        // Manual matrix multiplication for 2x2 case
+        C[0] = A[0] * B[0] + A[2] * B[1];  // C[0,0]
+        C[1] = A[1] * B[0] + A[3] * B[1];  // C[1,0]
+        C[2] = A[0] * B[2] + A[2] * B[3];  // C[0,1]
+        C[3] = A[1] * B[2] + A[3] * B[3];  // C[1,1]
+    }
+    
+    // Allocate device memory for matrices
+    std::vector<void*> A_dev_ptrs(batch_count), B_dev_ptrs(batch_count), C_dev_ptrs(batch_count);
+    for (int i = 0; i < batch_count; i++) {
+        hipMalloc(&A_dev_ptrs[i], lda * k * sizeof(double _Complex));
+        hipMalloc(&B_dev_ptrs[i], ldb * n * sizeof(double _Complex));
+        hipMalloc(&C_dev_ptrs[i], ldc * n * sizeof(double _Complex));
+        
+        hipMemcpy(A_dev_ptrs[i], &A_host[i * lda * k], lda * k * sizeof(double _Complex), hipMemcpyHostToDevice);
+        hipMemcpy(B_dev_ptrs[i], &B_host[i * ldb * n], ldb * n * sizeof(double _Complex), hipMemcpyHostToDevice);
+        hipMemcpy(C_dev_ptrs[i], &C_host[i * ldc * n], ldc * n * sizeof(double _Complex), hipMemcpyHostToDevice);
+    }
+    
+    // Allocate device memory for pointer arrays
+    void **A_dev_ptr_array, **B_dev_ptr_array, **C_dev_ptr_array;
+    hipMalloc(&A_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&B_dev_ptr_array, batch_count * sizeof(void*));
+    hipMalloc(&C_dev_ptr_array, batch_count * sizeof(void*));
+    
+    // Copy pointer arrays to device
+    hipMemcpy(A_dev_ptr_array, A_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(B_dev_ptr_array, B_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    hipMemcpy(C_dev_ptr_array, C_dev_ptrs.data(), batch_count * sizeof(void*), hipMemcpyHostToDevice);
+    
+    // Execute zGemmBatched
+    H4I::MKLShim::zGemmBatched(context, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS, H4I::MKLShim::ONEMKL_TRANSPOSE_NONTRANS,
+                               m, n, k, alpha,
+                               reinterpret_cast<const double _Complex* const*>(A_dev_ptr_array), lda,
+                               reinterpret_cast<const double _Complex* const*>(B_dev_ptr_array), ldb, beta,
+                               reinterpret_cast<double _Complex* const*>(C_dev_ptr_array), ldc, batch_count);
+    
+    hipDeviceSynchronize();
+    
+    // Copy results back
+    std::vector<double _Complex> C_result(batch_count * ldc * n);
+    for (int i = 0; i < batch_count; i++) {
+        hipMemcpy(&C_result[i * ldc * n], C_dev_ptrs[i], ldc * n * sizeof(double _Complex), hipMemcpyDeviceToHost);
+    }
+    
+    // Cleanup
+    for (int i = 0; i < batch_count; i++) {
+        hipFree(A_dev_ptrs[i]);
+        hipFree(B_dev_ptrs[i]);
+        hipFree(C_dev_ptrs[i]);
+    }
+    hipFree(A_dev_ptr_array);
+    hipFree(B_dev_ptr_array);
+    hipFree(C_dev_ptr_array);
+    
+    // Verify results
+    const double tolerance = 1e-12;
+    bool success = true;
+    for (int i = 0; i < batch_count * ldc * n; i++) {
+        double real_diff = fabs(creal(C_result[i]) - creal(C_expected[i]));
+        double imag_diff = fabs(cimag(C_result[i]) - cimag(C_expected[i]));
+        if (real_diff > tolerance || imag_diff > tolerance) {
+            std::cout << "Mismatch at index " << i << ": expected (" 
+                      << creal(C_expected[i]) << ", " << cimag(C_expected[i]) 
+                      << "), got (" << creal(C_result[i]) << ", " << cimag(C_result[i]) 
+                      << ")" << std::endl;
+            success = false;
+        }
+    }
+    
+    if (success) {
+        std::cout << "zGemmBatched test PASSED" << std::endl;
+    } else {
+        std::cout << "zGemmBatched test FAILED" << std::endl;
+    }
+    
+    return success;
+}
+
 int main() {
     std::cout << "MKLShim Batch Functions Correctness Test" << std::endl;
     std::cout << "=========================================" << std::endl;
@@ -619,6 +1345,13 @@ int main() {
     // allTestsPassed &= testSgetrfCorrectnessCPU(context);
     std::cout << "Sgetrf correctness: SKIPPED" << std::endl;
     allTestsPassed &= testSgetrfCorrectnessCPU(context);
+    allTestsPassed &= testDGemmBatchedExCorrectness(context);
+    allTestsPassed &= testCGemmBatchedExCorrectness(context);
+    allTestsPassed &= testZGemmBatchedExCorrectness(context);
+    allTestsPassed &= testSGemmBatchedCorrectness(context);
+    allTestsPassed &= testDGemmBatchedCorrectness(context);
+    allTestsPassed &= testCGemmBatchedCorrectness(context);
+    allTestsPassed &= testZGemmBatchedCorrectness(context);
     
     // Ensure all GPU operations are complete before cleanup
     std::cout << "\nSynchronizing all GPU operations..." << std::endl;


### PR DESCRIPTION
* dGemmBatchedEx
* cGemmBatchedEx
* zGemmBatchedEx
* sGemmBatched
* dGemmBatched
* cGemmBatched
* zGemmBatched

Remove FORCE_FLUSH since it's causing a segfault on L0 backend during get_native event and appears to be redundant when wait_and_throw() is used