### PR TITLE
fft: cuFFT-compatible 3D R2C layout

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -64,6 +64,10 @@ jobs:
           export OverrideDefaultFP64Settings=1
           export CHIP_LOGLEVEL=err
           cd build
+          # HIP/chipStar/main module exposes a pre-installed libMKLShim.so on
+          # LD_LIBRARY_PATH, which would override our freshly built one. Pin
+          # the just-built library first so ctest exercises THIS PR's code.
+          export LD_LIBRARY_PATH="$PWD/src:${LD_LIBRARY_PATH:-}"
           # Skips (both unrelated to this PR — to be fixed in follow-ups):
           #   h4i-mklshim_handle_management_test
           #     Pre-existing refcount regression triggered by the
@@ -100,6 +104,9 @@ jobs:
           export IGC_EnableDPEmulation=1
           export OverrideDefaultFP64Settings=1
           export CHIP_LOGLEVEL=err
+          # Pin this PR's freshly built MKLShim ahead of the one bundled with
+          # the HIP/chipStar/main module on LD_LIBRARY_PATH.
+          export LD_LIBRARY_PATH="$PREFIX/lib:${LD_LIBRARY_PATH:-}"
 
           DOWNSTREAM="$GITHUB_WORKSPACE/downstream"
           rm -rf "$DOWNSTREAM" && mkdir -p "$DOWNSTREAM"

--- a/include/h4i/mklshim/onemklfft.h
+++ b/include/h4i/mklshim/onemklfft.h
@@ -31,6 +31,12 @@ namespace H4I::MKLShim
 
   void recommitFFTDescriptorSR(Context *ctxt, fftDescriptorSR *desc);
 
+  // Rebind each FFT descriptor type onto ctxt->queue (after SetStream/Update).
+  void rebindFFTDescriptorSR(Context *ctxt, fftDescriptorSR *desc);
+  void rebindFFTDescriptorSC(Context *ctxt, fftDescriptorSC *desc);
+  void rebindFFTDescriptorDR(Context *ctxt, fftDescriptorDR *desc);
+  void rebindFFTDescriptorDC(Context *ctxt, fftDescriptorDC *desc);
+
   // destroy the fft descriptor
   void destroyFFTDescriptorSR(Context *ctxt, fftDescriptorSR *descSR);
   void destroyFFTDescriptorSC(Context *ctxt, fftDescriptorSC *descSC);

--- a/src/onemklfft.cpp
+++ b/src/onemklfft.cpp
@@ -42,9 +42,27 @@ namespace H4I::MKLShim
       // descriptor for multi-dimensional transforms
       fftDescriptorSR(Context* ctxt, std::vector<std::int64_t> dimensions) : fft_plan(dimensions)
       {
-          // commit the plan
+          // cuFFT-compatible layout: store output as N/2+1 interleaved complex
+          // values along the last dim (not oneMKL's default packed CCE format),
+          // with NOT_INPLACE placement and contiguous row-major strides.
+          if (dimensions.size() >= 2) {
+              fft_plan.set_value(oneapi::mkl::dft::config_param::PLACEMENT, DFTI_NOT_INPLACE);
+              fft_plan.set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
+                                 DFTI_COMPLEX_COMPLEX);
+              std::vector<std::int64_t> fwd_strides(dimensions.size() + 1, 0);
+              std::vector<std::int64_t> bwd_strides(dimensions.size() + 1, 0);
+              std::int64_t s = 1, cs = 1;
+              for (int i = dimensions.size() - 1; i >= 0; i--) {
+                  fwd_strides[i + 1] = s;
+                  bwd_strides[i + 1] = cs;
+                  s *= dimensions[i];
+                  cs *= (i == (int)dimensions.size() - 1)
+                            ? (dimensions[i] / 2 + 1) : dimensions[i];
+              }
+              fft_plan.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, fwd_strides);
+              fft_plan.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, bwd_strides);
+          }
           fft_plan.commit(ctxt->queue);
-          // wait for everything to complete before continuing
           ctxt->queue.wait();
       }
 
@@ -164,9 +182,25 @@ namespace H4I::MKLShim
       // descriptor for multi-dimensional transforms
       fftDescriptorDR(Context* ctxt, std::vector<std::int64_t> dimensions) : fft_plan(dimensions)
       {
-          // commit the plan
+          // cuFFT-compatible layout: see fftDescriptorSR multi-dim ctor for rationale.
+          if (dimensions.size() >= 2) {
+              fft_plan.set_value(oneapi::mkl::dft::config_param::PLACEMENT, DFTI_NOT_INPLACE);
+              fft_plan.set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
+                                 DFTI_COMPLEX_COMPLEX);
+              std::vector<std::int64_t> fwd_strides(dimensions.size() + 1, 0);
+              std::vector<std::int64_t> bwd_strides(dimensions.size() + 1, 0);
+              std::int64_t s = 1, cs = 1;
+              for (int i = dimensions.size() - 1; i >= 0; i--) {
+                  fwd_strides[i + 1] = s;
+                  bwd_strides[i + 1] = cs;
+                  s *= dimensions[i];
+                  cs *= (i == (int)dimensions.size() - 1)
+                            ? (dimensions[i] / 2 + 1) : dimensions[i];
+              }
+              fft_plan.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, fwd_strides);
+              fft_plan.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, bwd_strides);
+          }
           fft_plan.commit(ctxt->queue);
-          // wait for everything to complete before continuing
           ctxt->queue.wait();
 
 	  // use the soon-to-be default (can be removed in the future) for storing complex numbers

--- a/src/onemklfft.cpp
+++ b/src/onemklfft.cpp
@@ -49,18 +49,18 @@ namespace H4I::MKLShim
               fft_plan.set_value(oneapi::mkl::dft::config_param::PLACEMENT, DFTI_NOT_INPLACE);
               fft_plan.set_value(oneapi::mkl::dft::config_param::CONJUGATE_EVEN_STORAGE,
                                  DFTI_COMPLEX_COMPLEX);
-              std::vector<std::int64_t> fwd_strides(dimensions.size() + 1, 0);
-              std::vector<std::int64_t> bwd_strides(dimensions.size() + 1, 0);
+              stored_fwd_strides.assign(dimensions.size() + 1, 0);
+              stored_bwd_strides.assign(dimensions.size() + 1, 0);
               std::int64_t s = 1, cs = 1;
               for (int i = dimensions.size() - 1; i >= 0; i--) {
-                  fwd_strides[i + 1] = s;
-                  bwd_strides[i + 1] = cs;
+                  stored_fwd_strides[i + 1] = s;
+                  stored_bwd_strides[i + 1] = cs;
                   s *= dimensions[i];
                   cs *= (i == (int)dimensions.size() - 1)
                             ? (dimensions[i] / 2 + 1) : dimensions[i];
               }
-              fft_plan.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, fwd_strides);
-              fft_plan.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, bwd_strides);
+              fft_plan.set_value(oneapi::mkl::dft::config_param::FWD_STRIDES, stored_fwd_strides);
+              fft_plan.set_value(oneapi::mkl::dft::config_param::BWD_STRIDES, stored_bwd_strides);
           }
           fft_plan.commit(ctxt->queue);
           ctxt->queue.wait();
@@ -357,6 +357,22 @@ namespace H4I::MKLShim
 
   void recommitFFTDescriptorSR(Context* ctxt, fftDescriptorSR* desc) {
      desc->recommit(ctxt);
+  }
+
+  // Re-commit each descriptor on ctxt->queue.  Used by hipfftSetStream after
+  // updating the context's SYCL queue, so subsequent compute_* submissions
+  // land on the new queue rather than the one captured at the original commit.
+  void rebindFFTDescriptorSR(Context* ctxt, fftDescriptorSR* desc) {
+      if (desc != nullptr) { desc->fft_plan.commit(ctxt->queue); ctxt->queue.wait(); }
+  }
+  void rebindFFTDescriptorSC(Context* ctxt, fftDescriptorSC* desc) {
+      if (desc != nullptr) { desc->fft_plan.commit(ctxt->queue); ctxt->queue.wait(); }
+  }
+  void rebindFFTDescriptorDR(Context* ctxt, fftDescriptorDR* desc) {
+      if (desc != nullptr) { desc->fft_plan.commit(ctxt->queue); ctxt->queue.wait(); }
+  }
+  void rebindFFTDescriptorDC(Context* ctxt, fftDescriptorDC* desc) {
+      if (desc != nullptr) { desc->fft_plan.commit(ctxt->queue); ctxt->queue.wait(); }
   }
 
   // execute the plans

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -30,6 +30,13 @@ target_include_directories(mklshim_handle_management_test PRIVATE
                           ${CMAKE_SOURCE_DIR}/include)
 target_compile_options(mklshim_handle_management_test PRIVATE -fsycl)
 
+# Reproducer: 3D R2C must produce cuFFT-compatible interleaved-complex output
+add_executable(mklshim_fft_3d_cufft_layout_test fft_3d_cufft_layout_test.cpp)
+target_link_libraries(mklshim_fft_3d_cufft_layout_test PRIVATE MKLShim hip::host)
+target_include_directories(mklshim_fft_3d_cufft_layout_test PRIVATE
+                          ${CMAKE_BINARY_DIR}/include
+                          ${CMAKE_SOURCE_DIR}/include)
+
 # Add tests to CTest
 add_test(NAME h4i-mklshim_context_test COMMAND mklshim_context_test) 
 set_tests_properties(h4i-mklshim_context_test PROPERTIES 
@@ -46,3 +53,7 @@ set_tests_properties(h4i-mklshim_batch_correctness_test PROPERTIES
 add_test(NAME h4i-mklshim_handle_management_test COMMAND mklshim_handle_management_test)
 set_tests_properties(h4i-mklshim_handle_management_test PROPERTIES
     PASS_REGULAR_EXPRESSION "All handle management tests passed successfully!")
+
+add_test(NAME h4i-mklshim_fft_3d_cufft_layout_test COMMAND mklshim_fft_3d_cufft_layout_test)
+set_tests_properties(h4i-mklshim_fft_3d_cufft_layout_test PROPERTIES
+    PASS_REGULAR_EXPRESSION "All cuFFT-layout 3D R2C tests passed!")

--- a/test/fft_3d_cufft_layout_test.cpp
+++ b/test/fft_3d_cufft_layout_test.cpp
@@ -1,0 +1,68 @@
+// Reproduces: 3D R2C output in default packed CCE storage doesn't match
+// cuFFT's interleaved-complex layout that consumers (OpenMM, etc.) expect.
+// With input all-ones, DC bin should equal N0*N1*N2 (sum of input).  Before
+// the fix it returns a wrong value because OUTPUT_STRIDES sit in real units
+// for COMPLEX_REAL storage rather than complex units for the cuFFT layout.
+#include <cstdlib>
+#include <iostream>
+#include <vector>
+#include <hip/hip_runtime.h>
+#include <hip/hip_interop.h>
+#include "h4i/mklshim/mklshim.h"
+#include "h4i/mklshim/onemklfft.h"
+
+int main() {
+    int nHandles;
+    hipGetBackendNativeHandles((uintptr_t)0, 0, &nHandles);
+    std::vector<unsigned long> handles(nHandles);
+    hipGetBackendNativeHandles((uintptr_t)NULL, handles.data(), 0);
+    H4I::MKLShim::Context* ctxt = H4I::MKLShim::Create(handles.data(), nHandles);
+    if (!ctxt) { std::cerr << "FAILED: Context creation" << std::endl; return EXIT_FAILURE; }
+
+    const int N = 4;
+    const size_t in_count  = (size_t)N * N * N;
+    const size_t out_count = (size_t)N * N * (N/2 + 1);
+
+    auto* desc = H4I::MKLShim::createFFTDescriptorSR(ctxt,
+                    std::vector<std::int64_t>{N, N, N});
+    if (!desc) { std::cerr << "FAILED: descriptor" << std::endl; return EXIT_FAILURE; }
+
+    float* d_in = nullptr;
+    float _Complex* d_out = nullptr;
+    if (hipMalloc(&d_in, in_count * sizeof(float)) != hipSuccess ||
+        hipMalloc(&d_out, out_count * sizeof(float _Complex)) != hipSuccess) {
+        std::cerr << "FAILED: hipMalloc" << std::endl; return EXIT_FAILURE;
+    }
+    std::vector<float> host_in(in_count, 1.0f);
+    hipMemcpy(d_in, host_in.data(), in_count * sizeof(float), hipMemcpyHostToDevice);
+
+    H4I::MKLShim::fftExecR2C(ctxt, desc, d_in, d_out);
+
+    std::vector<float _Complex> host_out(out_count);
+    hipMemcpy(host_out.data(), d_out, out_count * sizeof(float _Complex), hipMemcpyDeviceToHost);
+
+    const float dc_re = __real__ host_out[0];
+    const float dc_im = __imag__ host_out[0];
+    const float expected_dc = (float)in_count;  // N^3 = 64
+    if (dc_re != expected_dc || dc_im != 0.0f) {
+        std::cerr << "FAILED: 3D R2C DC expected (" << expected_dc << ", 0), got ("
+                  << dc_re << ", " << dc_im << ")" << std::endl;
+        return EXIT_FAILURE;
+    }
+    // All other bins must be exactly 0 for all-ones input.
+    for (size_t i = 1; i < out_count; i++) {
+        if (__real__ host_out[i] != 0.0f || __imag__ host_out[i] != 0.0f) {
+            std::cerr << "FAILED: bin " << i << " expected (0,0) got ("
+                      << __real__ host_out[i] << ", " << __imag__ host_out[i] << ")"
+                      << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
+    H4I::MKLShim::destroyFFTDescriptorSR(ctxt, desc);
+    hipFree(d_in); hipFree(d_out);
+    H4I::MKLShim::Destroy(ctxt);
+
+    std::cout << "All cuFFT-layout 3D R2C tests passed!" << std::endl;
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
3D R2C output now matches cuFFT's interleaved-complex layout instead of oneMKL's default packed CCE storage.