### PR TITLE
ci: install shared module from main instead of develop

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -2,7 +2,7 @@ name: H4I-MKLShim Install
 
 on:
   push:
-    branches: [ "develop" ]
+    branches: [ "main" ]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

The `install.yml` workflow rebuilds the shared MKLShim module (`/home/pvelesko/install/HIP/H4I-MKLShim/oneapi-*`) that **all downstream CI links against** (HipFFT, HipBLAS, HipSOLVER). It triggered on push to `develop`, but develop is months behind `main` and lacks fixes that already landed on main — notably the D2Z/Z2D/Z2Zforward implementations from #49 (`f63c719`).

As a result, downstream presubmits linked a **stale** installed module and failed on bugs already fixed upstream. This surfaced in H4I-HipFFT PR #11, where `hipfft_missing_symbols` failed with the original `got -0.3125 expected -5` no-op signature even though the fix is on MKLShim main.

## Change

- `install.yml`: trigger on push to **main** instead of develop, so the shared module tracks the branch that carries the fixes.

## Validation

- This PR's presubmit builds MKLShim from this branch (= main + trigger change) and runs the downstream H4I-HipFFT@main test suite against it, which exercises the D2Z/Z2D path.
- After merge, the push to main fires `install.yml`, refreshing the shared module; downstream HipFFT CI then links the fixed library.