### PR TITLE
fft: sync after D2Z/Z2D compute so L0 readback can't race

### DIFF
--- a/src/onemklfft.cpp
+++ b/src/onemklfft.cpp
@@ -532,6 +532,11 @@ namespace H4I::MKLShim
           }
 
           oneapi::mkl::dft::compute_forward(descDR->fft_plan, idata);
+          // On L0 the MKL compute submission is not ordered against the
+          // caller's subsequent HIP memcpy on chipStar's stream, so the
+          // readback can race ahead and observe stale data. Sync here, as
+          // fftExecZ2Zbackward already does.
+          ctxt->queue.wait();
       }
       else
       {
@@ -544,6 +549,7 @@ namespace H4I::MKLShim
 
           oneapi::mkl::dft::compute_forward(descDR->fft_plan, idata,
                                             reinterpret_cast<std::complex<double> *>(odata));
+          ctxt->queue.wait();
       }
   }
 
@@ -562,6 +568,9 @@ namespace H4I::MKLShim
           }
 
           oneapi::mkl::dft::compute_backward(descDR->fft_plan, odata);
+          // See fftExecD2Z: sync so a subsequent HIP readback on L0 cannot
+          // race ahead of the MKL compute.
+          ctxt->queue.wait();
       }
       else
       {
@@ -575,6 +584,7 @@ namespace H4I::MKLShim
           oneapi::mkl::dft::compute_backward(descDR->fft_plan,
                                              reinterpret_cast<std::complex<double> *>(idata),
                                              odata);
+          ctxt->queue.wait();
       }
   }
 


### PR DESCRIPTION
## Summary

`hipfftExecD2Z`/`hipfftExecZ2D` double-real round-trips returned the **original input unchanged** on the **Level0** backend (`got -5/16, expected -5`) while OpenCL passed. This blocked H4I-HipFFT PR #11 and surfaced in MKLShim PR #51's downstream test.

## Root cause

The double-real exec wrappers (`fftExecD2Z`/`fftExecZ2D`) submit the MKL DFT compute on the context's SYCL queue but **do not wait** afterward. On L0, chipStar's immediate command list does not order the MKL compute submission against the caller's subsequent HIP `hipMemcpy`, so the host readback races ahead and observes stale device memory. OpenCL's queue mapping happens to serialize the two, masking the bug.

Evidence:
- `fftExecZ2Zbackward` (double-**complex**) already guards against exactly this with a trailing `queue.wait()` → Z2Z passes on L0.
- The passing single-precision tests (`hipfft_real_1d`, `hipfft_complex_1d`) call `hipDeviceSynchronize()` after every exec, so they never race.
- `hipfft_missing_symbols` does **not** sync between the execs and the readback, which is why it exposed the missing internal sync in the D2Z/Z2D path.

## Change

Add `ctxt->queue.wait()` after `compute_forward`/`compute_backward` in both the inplace and not-inplace branches of `fftExecD2Z` and `fftExecZ2D`, mirroring `fftExecZ2Zbackward`.

## Validation

This PR's presubmit builds MKLShim from this branch and runs the downstream **H4I-HipFFT@main** suite on both OpenCL and Level0 — `hipfft_missing_symbols` (the D2Z/Z2D round-trip) must now pass on L0.