### PR TITLE
ci: fix install.yml toolchain so it builds main

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -10,35 +10,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build_and_test:
-    runs-on: [self-hosted, X64]
+  install:
+    runs-on: [self-hosted, Linux, X64]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: oneapi/2024.1.0
+      - name: Build & install MKLShim (oneapi/2025.0.4)
         shell: bash
         run: |
-          source /home/pvelesko/install/modules/init/bash
-          module use /home/pvelesko/modulefiles
-          module purge
-          module load llvm/19.0 HIP/chipStar/main oneapi/2024.1.0
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=/home/pvelesko/install/HIP/H4I-MKLShim/oneapi-2024.1.0
-          make -j$(nproc)
-          make install
+          set -e
+          if [ -f "$HOME/.local/init/bash" ]; then
+            export MODULESHOME=$HOME/.local
+            source "$MODULESHOME/init/bash"
+          elif [ -f /etc/profile.d/lmod.sh ]; then
+            source /etc/profile.d/lmod.sh
+          else
+            source /etc/profile.d/modules.sh
+          fi
+          module use /space/pvelesko/modulefiles
+          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main
+          module list
 
-      - name: oneapi/2025.0.4
-        shell: bash
-        run: |
-          source /home/pvelesko/install/modules/init/bash
-          module use /home/pvelesko/modulefiles
-          module purge
-          module load llvm/19.0 HIP/chipStar/main oneapi/2025.0.4
+          PREFIX=/home/pvelesko/install/HIP/H4I-MKLShim/oneapi-2025.0.4
           rm -rf build
-          mkdir build
-          cd build
-          cmake .. -DCMAKE_INSTALL_PREFIX=/home/pvelesko/install/HIP/H4I-MKLShim/oneapi-2025.0.4
-          make -j$(nproc)
-          make install
+          cmake -S . -B build \
+            -DCMAKE_CXX_COMPILER="$(which icpx)" \
+            -DINTEL_COMPILER_PATH="$(which icpx)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PREFIX" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake --build build -j 8 --target install
+          ls "$PREFIX/lib/libMKLShim.so" "$PREFIX/lib/cmake/MKLShim/MKLShimConfig.cmake"


### PR DESCRIPTION
## Summary

The install workflow (which rebuilds the shared module `/home/pvelesko/install/HIP/H4I-MKLShim/oneapi-2025.0.4` consumed by all downstream CI) used the default `c++` and the old `llvm/19.0` + `/home/pvelesko/modulefiles` environment. It failed at CMake compiler ABI detection (`c++: error: unrecognized command-line option '-R'`) and had been red since April, so the module was never refreshed — which is why downstream CI linked stale code.

## Change

- Rewrite the `oneapi/2025.0.4` install to mirror the proven `presubmit.yml` build environment: init-bash fallback, `/space/pvelesko/modulefiles`, `llvm/22.0-native`, and explicit `icpx` via `CMAKE_CXX_COMPILER` / `INTEL_COMPILER_PATH`.
- Drop the `oneapi/2024.1.0` step: failing for months, main is not validated against that toolchain (presubmit only builds 2025.0.4), and it blocked the 2025.0.4 install.

## Validation

Verified end-to-end via `workflow_dispatch` on this branch (run 26808781884, success): MKLShim main builds and installs cleanly into the shared module prefix.