### PR TITLE
Adding in code to do pivot array conversion on the device

### DIFF
--- a/include/h4i/mklshim/onemklsolver.h
+++ b/include/h4i/mklshim/onemklsolver.h
@@ -172,6 +172,18 @@ namespace H4I::MKLShim
   void Zgetrfnp_batch(Context* ctxt, int64_t* m, int64_t* n, double _Complex** A, int64_t* lda, int64_t group_count,
                       int64_t* group_sizes, double _Complex* scratchpad, int64_t scratchpad_size);
 
+  // pivot array conversion helpers
+
+  // Build the pointer list for an int64 pivot buffer: 
+  // ipiv_mkl_ptrs[i] = ipiv_mkl + i*n.
+  void make_ipiv_int64_ptr_list(Context* ctxt, int64_t* ipiv_mkl, int64_t** ipiv_mkl_ptrs,
+                                int64_t n, int64_t batchCount);
+  // Populate the int64 pivot buffer ipiv_mkl and build its per-batch pointer list
+  void convert_ipiv_to_int64_and_make_ptr_list(Context* ctxt, const int* ipiv_in, int64_t* ipiv_mkl,
+                                               int64_t** ipiv_mkl_ptrs, int64_t n, int64_t batchCount);
+  // Copy elements of a contiguous device int64 pivot buffer to a contiguous device int pivot buffer
+  void convert_ipiv_to_int32(Context* ctxt, const int64_t* ipiv_mkl, int* ipiv_out, int64_t count);
+
   //getri_batch (Group Version)
   /** Calculate scratchpad size for Sgetri_batch
    * @param ctxt MKLShim context

--- a/src/onemklsolver.cpp
+++ b/src/onemklsolver.cpp
@@ -1153,6 +1153,54 @@ namespace H4I::MKLShim
     ONEMKL_CATCH("Zgetrfnp_batch")
   }
 
+  // ipiv conversion helpers (device-side).
+  // The hipBLAS API gives pivots as int* (device), but oneMKL's group
+  // routines require an int64_t** pivot-pointer array. These run a SYCL kernel
+  // on the context queue so the copy-to-or-from-int64 and pointer-array assembly happen
+  // on the device
+
+  // Build the pointer list for an int64 pivot buffer
+  void make_ipiv_int64_ptr_list(Context* ctxt, int64_t* ipiv_mkl, int64_t** ipiv_mkl_ptrs,
+                                int64_t n, int64_t batchCount){
+    ONEMKL_TRY
+    auto status = ctxt->queue.parallel_for(sycl::range<1>(static_cast<size_t>(batchCount)),
+                                           [=](sycl::id<1> idx){
+      ipiv_mkl_ptrs[idx] = ipiv_mkl + static_cast<int64_t>(idx) * n;
+    });
+    ctxt->queue.wait();
+    __CATCH__("make_ipiv_int64_ptr_list")
+  }
+
+  // Populate the int64 pivot buffer ipiv_mkl and build its per-batch pointer list
+  // When ipiv_in != nullptr, copy the caller's int pivots into int62 ipiv_mkl;
+  // when ipiv_in == nullptr, fill ipiv_mkl with the 1-based identity permutation
+  // after this, make the pointer list based on ipiv_mkl
+  void convert_ipiv_to_int64_and_make_ptr_list(Context* ctxt, const int* ipiv_in, int64_t* ipiv_mkl,
+                                               int64_t** ipiv_mkl_ptrs, int64_t n, int64_t batchCount){
+    ONEMKL_TRY
+    auto status = ctxt->queue.parallel_for(sycl::range<1>(static_cast<size_t>(n * batchCount)),
+                                           [=](sycl::id<1> idx){
+      size_t t = idx;
+      if (ipiv_in != nullptr) ipiv_mkl[t] = static_cast<int64_t>(ipiv_in[t]);
+      else                    ipiv_mkl[t] = static_cast<int64_t>(t % n) + 1;
+      if (t < static_cast<size_t>(batchCount))
+        ipiv_mkl_ptrs[t] = ipiv_mkl + static_cast<int64_t>(t) * n;
+    });
+    ctxt->queue.wait();
+    __CATCH__("convert_ipiv_to_int64_and_make_ptr_list")
+  }
+
+  // Copy elements of a contiguous device int64 pivot buffer to a contiguous device int pivot buffer
+  void convert_ipiv_to_int32(Context* ctxt, const int64_t* ipiv_mkl, int* ipiv_out, int64_t count){
+    ONEMKL_TRY
+    auto status = ctxt->queue.parallel_for(sycl::range<1>(static_cast<size_t>(count)),
+                                           [=](sycl::id<1> idx){
+      ipiv_out[idx] = static_cast<int>(ipiv_mkl[idx]);
+    });
+    ctxt->queue.wait();
+    __CATCH__("convert_ipiv_to_int32")
+  }
+
   // getri_batch
   int64_t Sgetri_batch_ScPadSz(Context* ctxt, int64_t group_count, int64_t* n, int64_t* lda, int64_t* group_sizes){
     ONEMKL_TRY_RETURN(-1)


### PR DESCRIPTION
This adds helper functions for pivot array conversion to avoid round-trips in batched routines. Currently we copy the pivots from device to host, then edit on the host and then copy back to the device [0]. This allows all of this to be one via the helper routines. 

There are three type:

1. `make_ipiv_int64_ptr_list`: this is just build an int64 pointer list based on an input pivot array like `ipiv_mkl_ptrs[i] = ipiv_mkl + i*n.`
2. `convert_ipiv_to_int64_and_make_ptr_list`: this first converts an int pivot array to int64, and then makes a pointer list based on it
3. `convert_ipiv_to_int32` the opposite of 1), this converts a int64 pivot array to int by copying and casting each element.


[0] We have to do this copying since the hipBLAS API gives pivots as int* (device), but oneMKL's group LAPACK routines require an int64_t** pivot-pointer array. 

h/t to @whitesides1 for the prototype!