### PR TITLE
Adding in batched device copy A[b] -> C[b] for getri's in-place inversion

### DIFF
--- a/include/h4i/mklshim/onemklsolver.h
+++ b/include/h4i/mklshim/onemklsolver.h
@@ -183,6 +183,15 @@ namespace H4I::MKLShim
                                                int64_t** ipiv_mkl_ptrs, int64_t n, int64_t batchCount);
   // Copy elements of a contiguous device int64 pivot buffer to a contiguous device int pivot buffer
   void convert_ipiv_to_int32(Context* ctxt, const int64_t* ipiv_mkl, int* ipiv_out, int64_t count);
+  // Batched device copy A[b] -> C[b] (getri in-place inversion staging)
+  void Scopy_batch_a_to_c(Context* ctxt, const float** A, float** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount);
+  void Dcopy_batch_a_to_c(Context* ctxt, const double** A, double** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount);
+  void Ccopy_batch_a_to_c(Context* ctxt, const float _Complex** A, float _Complex** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount);
+  void Zcopy_batch_a_to_c(Context* ctxt, const double _Complex** A, double _Complex** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount);
 
   //getri_batch (Group Version)
   /** Calculate scratchpad size for Sgetri_batch

--- a/include/h4i/mklshim/onemklsolver.h
+++ b/include/h4i/mklshim/onemklsolver.h
@@ -172,6 +172,18 @@ namespace H4I::MKLShim
   void Zgetrfnp_batch(Context* ctxt, int64_t* m, int64_t* n, double _Complex** A, int64_t* lda, int64_t group_count,
                       int64_t* group_sizes, double _Complex* scratchpad, int64_t scratchpad_size);
 
+  // pivot array conversion helpers
+
+  // Build the pointer list for an int64 pivot buffer: 
+  // ipiv_mkl_ptrs[i] = ipiv_mkl + i*n.
+  void make_ipiv_int64_ptr_list(Context* ctxt, int64_t* ipiv_mkl, int64_t** ipiv_mkl_ptrs,
+                                int64_t n, int64_t batchCount);
+  // Populate the int64 pivot buffer ipiv_mkl and build its per-batch pointer list
+  void convert_ipiv_to_int64_and_make_ptr_list(Context* ctxt, const int* ipiv_in, int64_t* ipiv_mkl,
+                                               int64_t** ipiv_mkl_ptrs, int64_t n, int64_t batchCount);
+  // Copy elements of a contiguous device int64 pivot buffer to a contiguous device int pivot buffer
+  void convert_ipiv_to_int32(Context* ctxt, const int64_t* ipiv_mkl, int* ipiv_out, int64_t count);
+
   //getri_batch (Group Version)
   /** Calculate scratchpad size for Sgetri_batch
    * @param ctxt MKLShim context

--- a/src/onemklsolver.cpp
+++ b/src/onemklsolver.cpp
@@ -1201,6 +1201,49 @@ namespace H4I::MKLShim
     __CATCH__("convert_ipiv_to_int32")
   }
 
+  // Batched device copy A[b] -> C[b] for getri's in-place inversion. A and C are
+  // device arrays of device pointers (batchCount each).
+  template <typename T>
+  static void copy_batch_a_to_c_impl(Context* ctxt, const T** A, T** C,
+                                     int64_t n, int64_t lda, int64_t ldc, int64_t batchCount){
+    ONEMKL_TRY
+    size_t nn = static_cast<size_t>(n) * static_cast<size_t>(n);
+    // One work-item per matrix element.
+    auto status = ctxt->queue.parallel_for(
+        sycl::range<1>(static_cast<size_t>(batchCount) * nn),
+        [=](sycl::id<1> gid){
+      size_t work_item = gid;
+      size_t batch   = work_item / nn;               // which matrix
+      size_t elem   = work_item % nn;               // element within the matrix
+      size_t col = elem / static_cast<size_t>(n);
+      size_t row = elem % static_cast<size_t>(n);
+      C[batch][col * static_cast<size_t>(ldc) + row] = A[batch][col * static_cast<size_t>(lda) + row];
+    });
+    ctxt->queue.wait();
+    __CATCH__("copy_batch_a_to_c")
+  }
+
+  void Scopy_batch_a_to_c(Context* ctxt, const float** A, float** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount){
+    copy_batch_a_to_c_impl<float>(ctxt, A, C, n, lda, ldc, batchCount);
+  }
+  void Dcopy_batch_a_to_c(Context* ctxt, const double** A, double** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount){
+    copy_batch_a_to_c_impl<double>(ctxt, A, C, n, lda, ldc, batchCount);
+  }
+  void Ccopy_batch_a_to_c(Context* ctxt, const float _Complex** A, float _Complex** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount){
+    copy_batch_a_to_c_impl<std::complex<float>>(ctxt, reinterpret_cast<const std::complex<float>**>(A),
+                                                reinterpret_cast<std::complex<float>**>(C),
+                                                n, lda, ldc, batchCount);
+  }
+  void Zcopy_batch_a_to_c(Context* ctxt, const double _Complex** A, double _Complex** C,
+                          int64_t n, int64_t lda, int64_t ldc, int64_t batchCount){
+    copy_batch_a_to_c_impl<std::complex<double>>(ctxt, reinterpret_cast<const std::complex<double>**>(A),
+                                                 reinterpret_cast<std::complex<double>**>(C),
+                                                 n, lda, ldc, batchCount);
+  }
+
   // getri_batch
   int64_t Sgetri_batch_ScPadSz(Context* ctxt, int64_t group_count, int64_t* n, int64_t* lda, int64_t* group_sizes){
     ONEMKL_TRY_RETURN(-1)

--- a/src/onemklsolver.cpp
+++ b/src/onemklsolver.cpp
@@ -1153,6 +1153,54 @@ namespace H4I::MKLShim
     ONEMKL_CATCH("Zgetrfnp_batch")
   }
 
+  // ipiv conversion helpers (device-side).
+  // The hipBLAS API gives pivots as int* (device), but oneMKL's group
+  // routines require an int64_t** pivot-pointer array. These run a SYCL kernel
+  // on the context queue so the copy-to-or-from-int64 and pointer-array assembly happen
+  // on the device
+
+  // Build the pointer list for an int64 pivot buffer
+  void make_ipiv_int64_ptr_list(Context* ctxt, int64_t* ipiv_mkl, int64_t** ipiv_mkl_ptrs,
+                                int64_t n, int64_t batchCount){
+    ONEMKL_TRY
+    auto status = ctxt->queue.parallel_for(sycl::range<1>(static_cast<size_t>(batchCount)),
+                                           [=](sycl::id<1> idx){
+      ipiv_mkl_ptrs[idx] = ipiv_mkl + static_cast<int64_t>(idx) * n;
+    });
+    ctxt->queue.wait();
+    __CATCH__("make_ipiv_int64_ptr_list")
+  }
+
+  // Populate the int64 pivot buffer ipiv_mkl and build its per-batch pointer list
+  // When ipiv_in != nullptr, copy the caller's int pivots into int62 ipiv_mkl;
+  // when ipiv_in == nullptr, fill ipiv_mkl with the 1-based identity permutation
+  // after this, make the pointer list based on ipiv_mkl
+  void convert_ipiv_to_int64_and_make_ptr_list(Context* ctxt, const int* ipiv_in, int64_t* ipiv_mkl,
+                                               int64_t** ipiv_mkl_ptrs, int64_t n, int64_t batchCount){
+    ONEMKL_TRY
+    auto status = ctxt->queue.parallel_for(sycl::range<1>(static_cast<size_t>(n * batchCount)),
+                                           [=](sycl::id<1> idx){
+      size_t t = idx;
+      if (ipiv_in != nullptr) ipiv_mkl[t] = static_cast<int64_t>(ipiv_in[t]);
+      else                    ipiv_mkl[t] = static_cast<int64_t>(t % n) + 1;
+      if (t < static_cast<size_t>(batchCount))
+        ipiv_mkl_ptrs[t] = ipiv_mkl + static_cast<int64_t>(t) * n;
+    });
+    ctxt->queue.wait();
+    __CATCH__("convert_ipiv_to_int64_and_make_ptr_list")
+  }
+
+  // Copy elements of a contiguous device int64 pivot buffer to a contiguous device int pivot buffer
+  void convert_ipiv_to_int32(Context* ctxt, const int64_t* ipiv_mkl, int* ipiv_out, int64_t count){
+    ONEMKL_TRY
+    auto status = ctxt->queue.parallel_for(sycl::range<1>(static_cast<size_t>(count)),
+                                           [=](sycl::id<1> idx){
+      ipiv_out[idx] = static_cast<int>(ipiv_mkl[idx]);
+    });
+    ctxt->queue.wait();
+    __CATCH__("convert_ipiv_to_int32")
+  }
+
   // getri_batch
   int64_t Sgetri_batch_ScPadSz(Context* ctxt, int64_t group_count, int64_t* n, int64_t* lda, int64_t* group_sizes){
     ONEMKL_TRY_RETURN(-1)


### PR DESCRIPTION
This lands on top of PR #57 . In a similar manner, it avoids copying from device to host to device via a device kernel. This is specific to getri, where hipBLAS uses an out-of-place inversion but MKL uses an in-place inversion. Thus we first must copy factorized input A to C and send C to MKL's getri_batch. The copying of a batched C to A is what is covered here.